### PR TITLE
APM-215: Change error urls

### DIFF
--- a/components/schemas/ErrorCode.yaml
+++ b/components/schemas/ErrorCode.yaml
@@ -9,7 +9,7 @@ properties:
         system:
           type: string
           description: URI of the coding system specification.
-          example: https://my.spec.nhs.net/mycodingsystem
+          example: https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode
         version:
           type: string
           description: Version of the coding system in use.

--- a/patient-information-api.yaml
+++ b/patient-information-api.yaml
@@ -295,7 +295,7 @@ paths:
                         code: required
                         details:
                           coding:
-                            - system: "https://my.spec.nhs.net/mycodingsystem"
+                            - system: "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode"
                               version: '1'
                               code: tooFewSearchParams
                               display: Not enough search parameters were provided to be able to make a search
@@ -308,7 +308,7 @@ paths:
                         code: value
                         details:
                           coding:
-                            - system: "https://my.spec.nhs.net/mycodingsystem"
+                            - system: "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode"
                               version: '1'
                               code: invalidDateFormat
                               display: "birthdate has invalid format: 2000 is not in YYYY-MM-DD format"


### PR DESCRIPTION
# APM-215: sandbox - error messages - dummy URL in coding system

## Summary of Changes
* If I trigger an error condition on the PDS API sandbox, the error response includes a field "coding system" and the URL mentioned is a dummy URL.

## Merge Checklist
* [x] Is this PR linked to a ticket in JIRA or Github issues?
* [x] Does the spec pass `make test`?
* [x] Does the spec pass `make validate`?
* [x] Does the branch build in CI?
* [x] If there are any changes to the CI process, have they been verified?
