### PR TITLE
APM-198: Refer out ODS API Spec in intro

### DIFF
--- a/patient-information-api.yaml
+++ b/patient-information-api.yaml
@@ -70,6 +70,11 @@ info:
     - access for citizens, using NHS Login
     - unattended access - without smartcard - similar to the PDS SMSP API
 
+    ## Related APIs
+    The following APIs are also related to this API:
+
+    [Organisation Data Service FHIR API](https://developer.nhs.uk/apis/ods/) - use this to get full details for the organisations related to the patient, such as their registered GP or nominated pharmacy.
+
     ## Testing
     You can test this API in:
     * our [sandbox environment](/testing#sandbox-testing) for initial developer testing


### PR DESCRIPTION
# APM-198: PDS API - ODS API Links - Spec / Sandbox

## Summary of Changes
* The URLs should link to the existing live ODS service (Already Completed)
* The PDS API spec should also refer out to the ODS API spec as a dependency - maybe in the intro - "related APIs" and also in the relevant field descriptions

## Merge Checklist
* [x] Is this PR linked to a ticket in JIRA or Github issues?
* [x] Does the spec pass `make test`?
* [x] Does the spec pass `make validate`?
* [x] Does the branch build in CI?
* [x] If there are any changes to the CI process, have they been verified?
