### PR TITLE
APM-215 Add error urls to error responses

### DIFF
--- a/sandbox/app.js
+++ b/sandbox/app.js
@@ -101,7 +101,7 @@ const preResponse = function (request, h) {
             code: error.data.operationOutcomeCode,
             details: {
                 coding: [{
-                    system: "https://my.spec.nhs.net/mycodingsystem",
+                    system: "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
                     version: 1,
                     code: error.data.apiErrorCode,
                     display: error.message

--- a/specification/patient-demographics-service-api.yaml
+++ b/specification/patient-demographics-service-api.yaml
@@ -361,7 +361,7 @@ paths:
                     code: value
                     details:
                       coding:
-                        - system: "https://my.spec.nhs.net/mycodingsystem"
+                        - system: "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode"
                           version: '1'
                           code: invalidNHSNumber
                           display: NHS Number 9000000000 is not a valid NHS number
@@ -378,7 +378,7 @@ paths:
                     code: not-found
                     details:
                       coding:
-                        - system: "https://my.spec.nhs.net/mycodingsystem"
+                        - system: "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode"
                           version: '1'
                           code: patientNotFound
                           display: Patient with NHS number 9111231130 could not be found
@@ -485,7 +485,7 @@ paths:
                         code: required
                         details:
                           coding:
-                            - system: "https://my.spec.nhs.net/mycodingsystem"
+                            - system: "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode"
                               version: '1'
                               code: versionNotSupplied
                               display: If-Match header must be supplied to update this resource
@@ -498,7 +498,7 @@ paths:
                         code: value
                         details:
                           coding:
-                            - system: "https://my.spec.nhs.net/mycodingsystem"
+                            - system: "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode"
                               version: '1'
                               code: invalidNHSNumber
                               display: NHS Number 9000000000 is not a valid NHS number
@@ -511,7 +511,7 @@ paths:
                         code: required
                         details:
                           coding:
-                            - system: "https://my.spec.nhs.net/mycodingsystem"
+                            - system: "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode"
                               version: '1'
                               code: noPatchesSubmitted
                               display: No patches submitted
@@ -524,7 +524,7 @@ paths:
                         code: value
                         details:
                           coding:
-                            - system: "https://my.spec.nhs.net/mycodingsystem"
+                            - system: "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode"
                               version: '1'
                               code: invalidPatchOperation
                               display: "Invalid patch: Cannot perform the operation at a path that does not exist"
@@ -541,7 +541,7 @@ paths:
                     code: not-found
                     details:
                       coding:
-                        - system: "https://my.spec.nhs.net/mycodingsystem"
+                        - system: "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode"
                           version: '1'
                           code: patientNotFound
                           display: Patient with NHS number 9111231130 could not be found
@@ -560,7 +560,7 @@ paths:
                     code: value
                     details:
                       coding:
-                        - system: "https://my.spec.nhs.net/mycodingsystem"
+                        - system: "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode"
                           version: '1'
                           code: unsupportedMediaType
                           display: Must be application/json-patch+json
@@ -611,7 +611,7 @@ components:
                 code: conflict
                 details:
                   coding:
-                    - system: "https://my.spec.nhs.net/mycodingsystem"
+                    - system: "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode"
                       version: '1'
                       code: versionMismatch
                       display: This resource has changed since you last read. Please re-read and try again with the new version number.


### PR DESCRIPTION
# [APM-215](https://jira.digital.nhs.uk/browse/APM-215): PDS API - sandbox - error messages - dummy URL in coding system

## Summary of Changes
* If I trigger an error condition on the PD API sandbox, the error response includes a field "coding system" and the URL mentioned is a dummy URL. Fix it!

## Merge Checklist
* [ ] Is this PR linked to a ticket in JIRA or Github issues?
* [ ] Does the branch build in CI?
* [ ] If there are any changes to the CI process, have they been verified (with evidence)?
* [ ] If any new libraries are added, are their licenses compatible with the project license?
