### PR TITLE
APM-198 Remove ods-site-code enum value as it will never be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2020-01-31
+* Removed ods-site-code as a possible value for code system to identify a nominated pharmacy on Patient.
+
 ## 2020-01-30
 * Added automatic version calculation
 * `make publish` now adds version into output oas file

--- a/specification/components/schemas/extensions/NominatedPharmacy.yaml
+++ b/specification/components/schemas/extensions/NominatedPharmacy.yaml
@@ -21,10 +21,8 @@ properties:
           system:
             type: string
             description: ODS code system URL.
-            example: https://fhir.nhs.uk/Id/ods-organization-code
-            enum:
-              - https://fhir.nhs.uk/Id/ods-organization-code
-              - https://fhir.nhs.uk/Id/ods-site-code
+            default: https://fhir.nhs.uk/Id/ods-organization-code
+            readOnly: true
           value:
             type: string
             description: ODS code.


### PR DESCRIPTION
# [APM-198](https://jira.digital.nhs.uk/browse/APM-198): Remove ods-site-code enum value as it will never be used

## Summary of Changes
* Removes ods-site-code from NominatedPharmacy org type.

## Merge Checklist
This section is to be filled in by the reviewer.

* [x] Is this PR linked to a ticket in JIRA or Github issues?
* [x] Does the branch build in CI?
* [x] If there are any changes to the CI process, have they been verified (with evidence)?
* [x] Has the changelog been updated?
