### PR TITLE
APM-124 Fix references to dist/ in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2020-01-31
+* Fix some mistakes in the README that referred to a nonexistent directory: `publish` -> `dist`
+
 ## 2020-01-30
 * Added automatic version calculation
 * `make publish` now adds version into output oas file

--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ $ make install-hooks
 ### Make commands
 There are `make` commands that alias some of this functionality:
  * `test` -- Lints the definition
- * `publish` -- Outputs the specification as a **single file** into the `publish/` directory
+ * `publish` -- Outputs the specification as a **single file** into the `dist/` directory
  * `serve` -- Serves a preview of the specification in human-readable format
- * `release` -- copy the latest file from `publish/` to `public/`
  * `generate-examples` -- generate example objects from the specification
  * `validate` -- validate generated examples against FHIR R4
 
@@ -62,9 +61,8 @@ There are `make` commands that alias some of this functionality:
 Speccy does the lifting for the following npm scripts:
 
  * `test` -- Lints the definition
- * `publish` -- Outputs the specification as a **single file** into the `publish/` directory
+ * `publish` -- Outputs the specification as a **single file** into the `dist/` directory
  * `serve` -- Serves a preview of the specification in human-readable format
- * `release` -- copy the latest file from `publish/` to `public/`
 
 (Workflow detailed in a [post](https://developerjack.com/blog/2018/maintaining-large-design-first-api-specs/) on the *developerjack* blog.)
 


### PR DESCRIPTION
# [APM-124](https://jira.digital.nhs.uk/browse/APM-124): Fix references to dist/ in README

## Summary of Changes
* Fix references to non-existent publish/ folder (to dist/)

## Merge Checklist
This section is to be filled in by the reviewer.

* [x] Is this PR linked to a ticket in JIRA or Github issues?
* [x] Does the branch build in CI?
* [x] If there are any changes to the CI process, have they been verified (with evidence)?
* [x] Has the changelog been updated?
