### PR TITLE
APM 330 Tagging and spec upload may fail if workflow has been run previously

### DIFF
--- a/.github/workflows/continous-integration-workflow.yaml
+++ b/.github/workflows/continous-integration-workflow.yaml
@@ -69,6 +69,7 @@ jobs:
         id: create-release
         if: github.ref == 'refs/heads/master'
         uses: actions/create-release@v1
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -78,6 +79,7 @@ jobs:
       - name: Upload spec release asset
         if: github.ref == 'refs/heads/master'
         uses: actions/upload-release-asset@v1
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary 
* :robot: Release creation steps may fail when workflow has been run previously - allowing these steps to skip

## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [x] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [x] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [x] I have ensured the changelog has been updated by the submitter, if necessary.
