### PR TITLE
APM-364 Fix sandbox test step that was left in accidentally

### DIFF
--- a/.github/workflows/continous-integration-workflow.yaml
+++ b/.github/workflows/continous-integration-workflow.yaml
@@ -130,7 +130,7 @@ jobs:
         run: make deploy-proxy
 
       - name: Run sandbox tests (master only)
-        # if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         env:
           API_TEST_ENV_FILE_PATH: "tests/e2e/environments/sandbox.postman_environment.json"
           API_TEST_URL: ${{ secrets.API_TEST_URL }}


### PR DESCRIPTION
## Summary
* :robot: Disable a test step that should not have been enabled.

It seems when merging APM-295 I missed that the sandbox test step had the master condition commented out. This fixes that.

## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [x] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [x] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [x] I have ensured the changelog has been updated by the submitter, if necessary.
