### PR TITLE
Apm 381 sandbox hotfix

### DIFF
--- a/sandbox/package-lock.json
+++ b/sandbox/package-lock.json
@@ -1299,8 +1299,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lru-cache": {
       "version": "4.1.5",

--- a/sandbox/package.json
+++ b/sandbox/package.json
@@ -14,6 +14,7 @@
         "@hapi/joi": "^17.1.0",
         "fast-json-patch": "^3.0.0-1",
         "inert": "^5.1.3",
+        "lodash": "^4.17.15",
         "nhs-number-validator": "^1.1.1"
     },
     "devDependencies": {

--- a/scripts/deploy_proxy.sh
+++ b/scripts/deploy_proxy.sh
@@ -9,7 +9,6 @@ mkdir -p dist
 rm -rf dist/apiproxy
 cp -R apiproxy/ dist/
 sed -i "s/PROXY_BASE_PATH/$APIGEE_BASE_PATH/g" dist/apiproxy/proxies/default.xml
-mkdir -p dist/apiproxy/resources/hosted/mocks
-cp sandbox/*.js sandbox/*.json sandbox/*.yaml dist/apiproxy/resources/hosted/
-cp -L sandbox/mocks/*.json dist/apiproxy/resources/hosted/mocks/
+mkdir -p dist/apiproxy/resources/hosted
+rsync -av --copy-links --exclude="node_modules" sandbox/ dist/apiproxy/resources/hosted
 node_modules/.bin/apigeetool deployproxy --environments "$APIGEE_ENVIRONMENTS" --api "$APIGEE_APIPROXY" --directory dist/ --verbose


### PR DESCRIPTION
## Summary
* BUGFIX: Fix failing deployment

Two reasons for failure:
  * `deploy_proxy.sh` script was being too explicit/brittle when preparing the `dist/apiproxy/resouces/hosted/` directory - files were being excluded following refactoring of the sandbox.
 * `lodash` was not listed as a sandbox top-level dependency. This is required for the project to run as an Apigee hosted target. (Although curiously this did not affect us running is locally.)

## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [x] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [x] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [x] I have ensured the changelog has been updated by the submitter, if necessary.
