### PR TITLE
Alterations in absence of Ben Clarke

### DIFF
--- a/specification/personal-demographics.yaml
+++ b/specification/personal-demographics.yaml
@@ -1136,16 +1136,6 @@ paths:
         *	if no current `billing` address is provided, a `temp` address may take precedence over the `home` address, again if it is valid according to its period start and to dates.
         * if there is no valid, current `billing` and/or `temp` address, the `home` address must be used.
 
-        Where a `temp` address is provided a description must be sent.
-        The list of possible values are:
-        * `Second Home` - a patient's second home
-        * `Student Accommodation` - a patient's place of residence while at university
-        * `Respite Care Address` - where the patient resides during respite care
-        * `Temporary Residence Address` - where the patient resides for a specific period of time
-        * `Convalescence Home` - the address for a patient during a period of recovery
-        * `Mobile Home` - the address of a patient's mobile home, parked for a specific period of time, e.g. the address of a caravan park
-        * `Holiday Home` - the address for a patient during a holiday
-
         It should be noted that not all local systems support `temp` and `billing` addresses, so these are not uniformly maintained. Therefore, where the patient contact has clinical or business significance, the precedence of these addresses over the `home` address should be determined by a user wherever possible.
         When the end date for a `temp` or `billing` address passes, local systems should use the patient’s `home` address. It will be extremely rare that no home address is present on a patient record.
 
@@ -1156,6 +1146,14 @@ paths:
         * any `billing` address must have both a `period start` and a `period end` date. The provision of a period end date has particular importance in order to avoid correspondence addresses that are no longer relevant to the patient still being held as current data available to any system retrieving the patient record. A suggested default where no actual period end is known is 30 days later than the period start, up to a maximum of 12 months.
         * the date period is optional; where present they must be valid dates and the `end` date cannot be before the `start` date
         * the period `start` date is optional, however if provided cannot be a future date. If it is not provided it will default to the date of update
+        * where a `temp` address is provided a description must be sent using the `text` field, the list of possible values are:
+        ** `Second Home` - a patient's second home
+        ** `Student Accommodation` - a patient's place of residence while at university
+        ** `Respite Care Address` - where the patient resides during respite care
+        ** `Temporary Residence Address` - where the patient resides for a specific period of time
+        ** `Convalescence Home` - the address for a patient during a period of recovery
+        ** `Mobile Home` - the address of a patient's mobile home, parked for a specific period of time, e.g. the address of a caravan park
+        ** `Holiday Home` - the address for a patient during a holiday
 
         Valid pseudo postcodes are:
 


### PR DESCRIPTION
In the absence of Ben being available to correct some basic text in the YAML file, we have made some adjustments we would like checked by a reviewer.

1) line 1149 - we elected to use `text` rather than `address.text`, because the context was already address - is this consistent with the spec?

## Summary
* Routine Change

## Reviews Required
* [x] Dev
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
