### PR TITLE
Multiple API products per proxy

### DIFF
--- a/products/application-restricted.yml
+++ b/products/application-restricted.yml
@@ -1,0 +1,3 @@
+name: application-restricted # Will have SERVICE_NAME- prepended to this
+displayName: Personal Demographics Service - Application Restricted
+description: Access the Personal Demographics Service with reduced permisions.

--- a/products/user-restricted.yml
+++ b/products/user-restricted.yml
@@ -1,0 +1,5 @@
+name: ''
+displayName: Personal Demographics Service - User Restricted
+description: Full access to PDS functionality
+scopes:
+  - personal-demographics-service:USER-RESTRICTED

--- a/proxies/live/apiproxy/policies/AssignMessage.Errors.InsufficientScope.xml
+++ b/proxies/live/apiproxy/policies/AssignMessage.Errors.InsufficientScope.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<AssignMessage name="AssignMessage.Errors.InsufficientScope">
+  <AssignVariable>
+    <Name>pds.error.code</Name>
+    <Value>token</Value>
+  </AssignVariable>
+  <AssignVariable>
+    <Name>pds.error.coding.code</Name>
+    <Value>INVALID_SCOPE</Value>
+  </AssignVariable>
+  <AssignVariable>
+    <Name>pds.error.coding.display</Name>
+    <Value>Access token has invalid scope for PATCH method</Value>
+  </AssignVariable>
+  <AssignVariable>
+    <Name>pds.error.diagnostics</Name>
+    <Template>Your app has insufficient permissions to use this method. Please contact support.
+    </Template>
+  </AssignVariable>
+  <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+</AssignMessage>

--- a/proxies/live/apiproxy/policies/OAuthV2.VerifyAccessTokenWithUserRestrictedScope.xml
+++ b/proxies/live/apiproxy/policies/OAuthV2.VerifyAccessTokenWithUserRestrictedScope.xml
@@ -1,0 +1,4 @@
+<OAuthV2 async="false" continueOnError="false" enabled="true" name="OauthV2.VerifyAccessTokenWithUserRestrictedScope">
+  <Operation>VerifyAccessToken</Operation>
+  <Scope>personal-demographics-service:USER-RESTRICTED</Scope>
+</OAuthV2>

--- a/proxies/live/apiproxy/targets/ig3.xml
+++ b/proxies/live/apiproxy/targets/ig3.xml
@@ -16,6 +16,10 @@
                 <Name>OauthV2.VerifyAccessToken</Name>
             </Step>
             <Step>
+                <Name>OauthV2.VerifyAccessTokenWithUserRestrictedScope</Name>
+                <Condition>(request.method == "PATCH")</Condition>
+            </Step>
+            <Step>
                 <Name>Quota</Name>
             </Step>
             <Step>
@@ -31,8 +35,8 @@
                 <Name>KeyValueMapOperations.GetSecureVariables</Name>
             </Step>
             <Step>
-              <Name>AssignMessage.PopulateAsidFromApp</Name>
-              <Condition>(app.asid IsNot null)</Condition>
+                <Name>AssignMessage.PopulateAsidFromApp</Name>
+                <Condition>(app.asid IsNot null)</Condition>
             </Step>
             {% if REQUIRE_ASID == 'True' %}
             <Step>
@@ -125,6 +129,15 @@
             <Step>
                 <Name>AssignMessage.Errors.CatchAllMessage</Name>
             </Step>
+        </FaultRule>
+        <FaultRule name="insufficient_scope">
+            <Condition>(fault.name == "InsufficientScope")</Condition>
+            <Step>
+                <Name>AssignMessage.Errors.InsufficientScope</Name>
+            </Step>
+            <Step>
+                <Name>AssignMessage.Errors.CatchAllMessage</Name>
+            </Step>            
         </FaultRule>
         <FaultRule name="no_asid_provided">
             <Condition>(request.header.NHSD-ASID is null) or (not request.header.NHSD-ASID ~~ ".+")</Condition>


### PR DESCRIPTION
API Products definitions may now be placed in the ```/products``` directory as separate yaml files.