### PR TITLE
APM-1162 Change rate limiting policy to be kinder to burst loads

### DIFF
--- a/products/application-restricted-higher-ratelimit.yml
+++ b/products/application-restricted-higher-ratelimit.yml
@@ -8,7 +8,7 @@ attributes:
   - name: access
     value: public
   - name: ratelimit
-    value: 130ps
-quota: 7800
-quotaInterval: 1
+    value: 18000pm  # Approx 300ps, higher than quota to allow short burst loads
+quota: 39000 # 130tps
+quotaInterval: 5 # Smoothed to 5 limits to be kind to bursty loads
 quotaTimeUnit: minute

--- a/products/application-restricted-higher-ratelimit.yml
+++ b/products/application-restricted-higher-ratelimit.yml
@@ -9,6 +9,6 @@ attributes:
     value: public
   - name: ratelimit
     value: 7800pm # 130tps in 1s buckets
-quota: 39000 # 130tps
+quota: 7800 # 130tps
 quotaInterval: 1
 quotaTimeUnit: minute

--- a/products/application-restricted-higher-ratelimit.yml
+++ b/products/application-restricted-higher-ratelimit.yml
@@ -8,7 +8,7 @@ attributes:
   - name: access
     value: public
   - name: ratelimit
-    value: 18000pm  # Approx 300ps, higher than quota to allow short burst loads
+    value: 7800pm # 130tps in 1s buckets
 quota: 39000 # 130tps
-quotaInterval: 5 # Smoothed to 5 limits to be kind to bursty loads
+quotaInterval: 1
 quotaTimeUnit: minute

--- a/products/user-restricted-higher-ratelimit.yml
+++ b/products/user-restricted-higher-ratelimit.yml
@@ -10,7 +10,7 @@ attributes:
   - name: access
     value: public
   - name: ratelimit
-    value: 130ps
-quota: 7800
-quotaInterval: 1
+    value: 18000pm  # Approx 300ps, higher than quota to allow short burst loads
+quota: 39000 # 130tps
+quotaInterval: 5 # Smoothed to 5 limits to be kind to bursty loads
 quotaTimeUnit: minute

--- a/products/user-restricted-higher-ratelimit.yml
+++ b/products/user-restricted-higher-ratelimit.yml
@@ -11,6 +11,6 @@ attributes:
     value: public
   - name: ratelimit
     value: 7800pm # 130tps in 1s buckets
-quota: 39000 # 130tps
+quota: 7800 # 130tps
 quotaInterval: 1
 quotaTimeUnit: minute

--- a/products/user-restricted-higher-ratelimit.yml
+++ b/products/user-restricted-higher-ratelimit.yml
@@ -10,7 +10,7 @@ attributes:
   - name: access
     value: public
   - name: ratelimit
-    value: 18000pm  # Approx 300ps, higher than quota to allow short burst loads
+    value: 7800pm # 130tps in 1s buckets
 quota: 39000 # 130tps
-quotaInterval: 5 # Smoothed to 5 limits to be kind to bursty loads
+quotaInterval: 1
 quotaTimeUnit: minute

--- a/proxies/live/apiproxy/policies/Quota.xml
+++ b/proxies/live/apiproxy/policies/Quota.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<Quota name="Quota" type="calendar">
+<Quota name="Quota" type="rollingwindow">
     <DisplayName>Quota</DisplayName>
     <Allow count="300" countRef="apiproduct.developer.quota.limit"/>
     <Interval ref="apiproduct.developer.quota.interval">1</Interval>
     <TimeUnit ref="apiproduct.developer.quota.timeunit">minute</TimeUnit>
-    <StartTime>2020-3-30 12:00:00</StartTime>
 </Quota>

--- a/proxies/live/apiproxy/policies/SpikeArrest.xml
+++ b/proxies/live/apiproxy/policies/SpikeArrest.xml
@@ -2,4 +2,5 @@
 <SpikeArrest name="SpikeArrest">
   <DisplayName>SpikeArrest</DisplayName>
   <Rate ref="apiproduct.ratelimit">5ps</Rate>
+  <UseEffectiveCount>true</UseEffectiveCount>
 </SpikeArrest>


### PR DESCRIPTION
## Summary
* Change spike arrest resolution to per second buckets instead of per 10 ms
* Keep quota at effective 130ps, but change to a 1 minute rolling window (7800/1mins)
* Balance message handler spike arrest so the spike arrest value is always constant despite the amount of request handlers