### PR TITLE
APM-1162 Don't check status on sandboxes, they don't support it

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -65,6 +65,7 @@ extends:
               test_type: smoke
       - environment: internal-qa-sandbox
         make_spec_visible: true
+        enable_status_monitoring: false
         proxy_path: sandbox
         post_deploy:
           - template: templates/sandbox-tests.yml
@@ -80,6 +81,7 @@ extends:
           - internal_qa_sandbox
       - environment: sandbox
         proxy_path: sandbox
+        enable_status_monitoring: false
         post_deploy:
           - template: templates/sandbox-tests.yml
         depends_on:


### PR DESCRIPTION
Sandboxes in PDS don't support status checks -- they didn't used to run, and have still not figured out the cause of the failure.