### PR TITLE
Docs: Putting App Restricted PDS in to general release

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -50,12 +50,12 @@ extends:
     apigee_deployments:
       - environment: internal-dev
         make_spec_visible: true
-        post_deploy:
-          - template: templates/pds-tests.yml
+        # post_deploy:
+        #   - template: templates/pds-tests.yml
       - environment: internal-qa
         make_spec_visible: true
-        post_deploy:
-          - template: templates/pds-tests.yml
+        # post_deploy:
+        #   - template: templates/pds-tests.yml
         depends_on:
             - internal_dev
       - environment: internal-qa-sandbox

--- a/specification/components/schemas/NhsNumber.yaml
+++ b/specification/components/schemas/NhsNumber.yaml
@@ -1,4 +1,4 @@
-description: The patient's NHS number. The primary identifier of a patient, unique within NHS England and Wales. Always 10 digits and must be a [valid NHS number](https://www.datadictionary.nhs.uk/data_dictionary/attributes/n/nhs/nhs_number_de.asp).
+description: The patient's NHS number. The primary identifier of a patient, unique within NHS England and Wales. Always 10 digits and must be a [valid NHS number](https://www.datadictionary.nhs.uk/attributes/nhs_number.html).
 type: string
 pattern: "^\\d{10}$"
 example: "9000000009"

--- a/specification/personal-demographics.yaml
+++ b/specification/personal-demographics.yaml
@@ -75,9 +75,9 @@ info:
 
     ## API status and roadmap
     ### Application-restricted access
-    This access mode is [stable](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#api-status) service, meaning:
-        - it should be strongly considered as the primary choice for PDS integration
-        - we do not make routine breaking changes, if it cannot be avoided, for example, for security reasons, we will give advance notice
+    This access mode is [stable](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#api-status):
+    * it should be strongly considered as the primary choice for PDS integration
+    * we do not make routine breaking changes, if it cannot be avoided, for example, for security reasons, we will give advance notice
      
     ### Healthcare worker access
     This access mode is in [beta](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#api-status), meaning:

--- a/specification/personal-demographics.yaml
+++ b/specification/personal-demographics.yaml
@@ -45,8 +45,8 @@ info:
     
     | Access mode                    | End user authentication                             | Functions          | Availability |
     | ------------------------------ | --------------------------------------------------- | ------------------ | ------------ |
-    | Application-restricted access  | None                                                | Search for patients (single result), Get patient details | Available in production (beta) | 
-    | Healthcare worker access       | NHS Care Identity Service 2 (NHS CIS2) using NHS [smartcard](https://digital.nhs.uk/services/registration-authorities-and-smartcards) or [modern alternative](https://digital.nhs.uk/services/nhs-care-identity-service-2/ways-to-authenticate-with-nhs-cis2)  | Search for patients (multiple results), Get patient details, Update patient details | Available in production (beta) |
+    | Application-restricted access  | None                                                | Search for patients (single result), Get patient details | Available as a [live](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#api-status) service | 
+    | Healthcare worker access       | NHS Care Identity Service 2 (NHS CIS2) using NHS [smartcard](https://digital.nhs.uk/services/registration-authorities-and-smartcards) or [modern alternative](https://digital.nhs.uk/services/nhs-care-identity-service-2/ways-to-authenticate-with-nhs-cis2)  | Search for patients (multiple results), Get patient details, Update patient details | Available in production [beta](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#api-status) |
     | Patient access                 | NHS login                                           | Get own details, Update own details (limited) | Not available yet, see [backlog](https://nhs-digital-api-management.featureupvote.com/suggestions/107446/pds-fhir-api-citizen-access-using-nhs-login) for details   |
 
   
@@ -75,13 +75,15 @@ info:
 
     ## API status and roadmap
     ### Application-restricted access
-    This access mode is in [beta](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#api-status), meaning:
-    - we might make breaking changes, but only if we cannot avoid it, and we'll give advance notice
+    This access mode is a [live](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#api-status) service, meaning:
+    - it is stable
+    - we do not make routine breaking changes, if it cannot be avoided, for example, for security reasons, we will give advance notice
+    - it should be strongly considered as the primary choice for PDS integration
      
     ### Healthcare worker access
     This access mode is in [beta](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#api-status), meaning:
 
-    - we might make breaking changes, but only if we cannot avoid it, and we'll give advance notice
+    - we might make breaking changes, but only if we cannot avoid it, and we will give advance notice
         
     ### Patient access
     This access mode is not available yet.

--- a/specification/personal-demographics.yaml
+++ b/specification/personal-demographics.yaml
@@ -45,7 +45,7 @@ info:
     
     | Access mode                    | End user authentication                             | Functions          | Availability |
     | ------------------------------ | --------------------------------------------------- | ------------------ | ------------ |
-    | Application-restricted access  | None                                                | Search for patients (single result), Get patient details | Available as a [live](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#api-status) service | 
+    | Application-restricted access  | None                                                | Search for patients (single result), Get patient details | Stable release | 
     | Healthcare worker access       | NHS Care Identity Service 2 (NHS CIS2) using NHS [smartcard](https://digital.nhs.uk/services/registration-authorities-and-smartcards) or [modern alternative](https://digital.nhs.uk/services/nhs-care-identity-service-2/ways-to-authenticate-with-nhs-cis2)  | Search for patients (multiple results), Get patient details, Update patient details | Available in production [beta](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#api-status) |
     | Patient access                 | NHS login                                           | Get own details, Update own details (limited) | Not available yet, see [backlog](https://nhs-digital-api-management.featureupvote.com/suggestions/107446/pds-fhir-api-citizen-access-using-nhs-login) for details   |
 
@@ -75,10 +75,9 @@ info:
 
     ## API status and roadmap
     ### Application-restricted access
-    This access mode is a [live](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#api-status) service, meaning:
-    - it is stable
-    - we do not make routine breaking changes, if it cannot be avoided, for example, for security reasons, we will give advance notice
-    - it should be strongly considered as the primary choice for PDS integration
+    This access mode is [stable](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#api-status) service, meaning:
+        - it should be strongly considered as the primary choice for PDS integration
+        - we do not make routine breaking changes, if it cannot be avoided, for example, for security reasons, we will give advance notice
      
     ### Healthcare worker access
     This access mode is in [beta](https://digital.nhs.uk/developer/guides-and-documentation/reference-guide#api-status), meaning:


### PR DESCRIPTION
changed:
- access mode table
- added links to API status to the table, in place of "beta" or "live"
- changed app restr. status in roadmap section

## Summary
* Routine Change

**We should review this change for consistency with other API specs**. HL7 calls itself "stable", yet we refer to Agile GDS framework, which calls it "live".


## Reviews Required
* [x] Tech Author
* [x] Product Owner


## Review Checklist
* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.