### PR TITLE
RateLimiting needs to be specified per-minute to be enforced per-second

### DIFF
--- a/manifest_template.yml
+++ b/manifest_template.yml
@@ -11,7 +11,7 @@ APIGEE_ENVIRONMENTS:
           timeunit: minute
         spikeArrest:
           enabled: true
-          ratelimit: 10ps
+          ratelimit: 600pm # 10 requests per second
       app:
         quota:
           enabled: false
@@ -27,7 +27,7 @@ APIGEE_ENVIRONMENTS:
           enabled: false
         spikeArrest:
           enabled: false
-          ratelimit: 10ps  # Required as fed into required (but unused) ratelimit attribute of the API product
+          ratelimit: 600pm  # Required as fed into required (but unused) ratelimit attribute of the API product
       app:
         quota:
           enabled: false
@@ -44,7 +44,7 @@ APIGEE_ENVIRONMENTS:
           timeunit: minute
         spikeArrest:
           enabled: true
-          ratelimit: 10ps
+          ratelimit: 600pm # 10 requests per second
       app:
         quota:
           enabled: false
@@ -59,7 +59,7 @@ APIGEE_ENVIRONMENTS:
           enabled: false
         spikeArrest:
           enabled: false
-          ratelimit: 10ps  # Required as fed into required (but unused) ratelimit attribute of the API product
+          ratelimit: 600pm  # Required as fed into required (but unused) ratelimit attribute of the API product
       app:
         quota:
           enabled: false
@@ -76,7 +76,7 @@ APIGEE_ENVIRONMENTS:
           timeunit: minute
         spikeArrest:
           enabled: true
-          ratelimit: 1050ps
+          ratelimit: 63000pm # 1050 requests per second
       app:
         quota:
           enabled: false
@@ -92,7 +92,7 @@ APIGEE_ENVIRONMENTS:
           enabled: false
         spikeArrest:
           enabled: false
-          ratelimit: 10ps  # Required as fed into required (but unused) ratelimit attribute of the API product
+          ratelimit: 600pm  # Required as fed into required (but unused) ratelimit attribute of the API product
       app:
         quota:
           enabled: false
@@ -109,7 +109,7 @@ APIGEE_ENVIRONMENTS:
           timeunit: minute
         spikeArrest:
           enabled: true
-          ratelimit: 40ps
+          ratelimit: 2400pm # 40 requests per second
       app:
         quota:
           enabled: false
@@ -127,7 +127,7 @@ APIGEE_ENVIRONMENTS:
           timeunit: minute
         spikeArrest:
           enabled: true
-          ratelimit: 540ps
+          ratelimit: 32400pm # 540 requests per second
       app:
         quota:
           enabled: true
@@ -136,7 +136,7 @@ APIGEE_ENVIRONMENTS:
           timeunit: minute
         spikeArrest:
           enabled: true
-          ratelimit: 10ps
+          ratelimit: 600pm # 10 requests per second
 
 ACCESS_MODES:
   - name: user-restricted


### PR DESCRIPTION
At present the Int limit is specified as 40ps which is enforced as 1 request every 25 milliseconds (1000/40)

Changing to per-minute by specifying 2400pm will be enforced as 40 requests every second (2400/60) 

See the docs for more info: https://docs.apigee.com/api-platform/develop/rate-limiting#spikearrest

## Summary
* Routine Change
* :exclamation: Breaking Change
* :robot: Operational or Infrastructure Change
* :sparkles: New Feature
* :warning: Potential issues that might be caused by this change

Add any other relevant notes or explanations here. **Remove this line if you have nothing to add.**


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
