### PR TITLE
AMB-939 - remove system from required fields on ContactPoint.yml sche…

### DIFF
--- a/specification/components/schemas/ContactPoint.yaml
+++ b/specification/components/schemas/ContactPoint.yaml
@@ -1,7 +1,6 @@
 description: A contact point, such as a phone number or email address
 type: object
 required:
-  - system
   - value
 properties:
   id:


### PR DESCRIPTION
for /patient/id the spec says that "system" is required however when calling /patient/9691715791 on INT we can see that 'system' is not part of the response therefore is not required. 

Action: Remove 'system' from the required field on ContactPoint schema.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
