### PR TITLE
Fix validator in build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 2023-07-25
+* Updated the Makefile to use the latest version of the hapifhir validator
+
 ## 2023-06-26
 * Documentation: Added address-postalcode as a search parameter in personal-demographics.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install-hooks:
 
 install-fhir-validator:
 	mkdir -p bin
-	test -f bin/org.hl7.fhir.validator.jar || curl -L https://github.com/hapifhir/org.hl7.fhir.core/releases/download/5.6.117/validator_cli.jar > bin/org.hl7.fhir.validator.jar
+	test -f bin/org.hl7.fhir.validator.jar || curl -L https://github.com/hapifhir/org.hl7.fhir.core/releases/download/6.0.1/validator_cli.jar > bin/org.hl7.fhir.validator.jar
 
 lint:
 	npm run lint

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install-hooks:
 
 install-fhir-validator:
 	mkdir -p bin
-	test -f bin/org.hl7.fhir.validator.jar || curl -L https://github.com/hapifhir/org.hl7.fhir.core/releases/download/6.0.1/validator_cli.jar > bin/org.hl7.fhir.validator.jar
+	test -f bin/org.hl7.fhir.validator.jar || curl -L https://github.com/hapifhir/org.hl7.fhir.core/releases/download/6.0.22/validator_cli.jar > bin/org.hl7.fhir.validator.jar
 
 lint:
 	npm run lint

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install-hooks:
 
 install-fhir-validator:
 	mkdir -p bin
-	test -f bin/org.hl7.fhir.validator.jar || curl -L https://github.com/hapifhir/org.hl7.fhir.core/releases/download/5.6.42/validator_cli.jar > bin/org.hl7.fhir.validator.jar
+	test -f bin/org.hl7.fhir.validator.jar || curl -L https://github.com/hapifhir/org.hl7.fhir.core/releases/download/5.6.117/validator_cli.jar > bin/org.hl7.fhir.validator.jar
 
 lint:
 	npm run lint

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ lint:
 	find -name '*.sh' | grep -v node_modules | xargs shellcheck
 
 validate: generate-examples
-	java -jar bin/org.hl7.fhir.validator.jar build/examples/**/*application_fhir+json*.json -version 4.0.1 -tx n/a | tee /tmp/validation.txt
+	java -jar bin/org.hl7.fhir.validator.jar build/examples/**/*application_fhir+json*.json -version 4.0.1 -tx n/a -extension any | tee /tmp/validation.txt
 
 publish: clean
 	mkdir -p build


### PR DESCRIPTION
## Summary
Updated the hapifhir validator to fix the build. Required a new parameter to be passed in to avoid validation errors

 :warning: The validator won't work in the dev VMs after this update

I don't think that the validator worked on our VMs anyway but I'm not sure why. However after this change it needs a newer version of Java than `sudo apt install default-jre default-jdk` installs. It works in Ubuntu installed via WSL


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
