### PR TITLE
Invalid URL in Relationship.yaml for UKCore-AdditionalRelatedPersonRole

### DIFF
--- a/specification/components/schemas/codeable/Relationship.yaml
+++ b/specification/components/schemas/codeable/Relationship.yaml
@@ -12,7 +12,7 @@ properties:
 
       The codes used can be found at:
       * http://hl7.org/fhir/ValueSet/relatedperson-relationshiptype
-      * https://fhir.nhs.uk/R4/CodeSystem/UKCore-AdditionalRelatedPersonRole
+      * INVALID URL - https://fhir.nhs.uk/R4/CodeSystem/UKCore-AdditionalRelatedPersonRole
 
       The allowed values for `Role` are:
       * Agent - Agent of patient


### PR DESCRIPTION
The URL https://fhir.nhs.uk/R4/CodeSystem/UKCore-AdditionalRelatedPersonRole returns a 500 Error

```
HTTP ERROR 500
Problem accessing /R4/CodeSystem/UKCore-AdditionalRelatedPersonRole. Reason:

    Server Error
```