### PR TITLE
SPINEDEM-1296 Correct proxy name

### DIFF
--- a/azure/templates/sandbox-tests.yml
+++ b/azure/templates/sandbox-tests.yml
@@ -10,7 +10,7 @@ steps:
       export STATUS_ENDPOINT_API_KEY="$(status-endpoint-api-key)"
       export APIGEE_ACCESS_TOKEN="$(secret.AccessToken)"
 
-      poetry run pytest -v tests/sandbox/test_sandbox.py --junitxml=tests/sandbox-test-report.xml --reruns 3 --reruns-delay 1 --proxy-name "$(SERVICE_NAME)-$(PR_LABEL)"
+      poetry run pytest -v tests/sandbox/test_sandbox.py --junitxml=tests/sandbox-test-report.xml --reruns 3 --reruns-delay 1 --proxy-name "$(FULLY_QUALIFIED_SERVICE_NAME)"
     displayName: Run sandbox tests
     workingDirectory: "$(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)"
 


### PR DESCRIPTION
## Summary
The proxy name passed to pytest in sandbox-test.yml was not dynamic enough to be used by other pipelines. This is to correct this error and make it sufficiently dynamic that the proxy name is correctly assigned according to the env/pipeline.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
