### PR TITLE
SPINEDEM-1296 add prod sandbox parameter to sandbox-tests

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -65,6 +65,8 @@ extends:
         enable_status_monitoring: false
         post_deploy:
           - template: templates/sandbox-tests.yml
+            parameters:
+            - is_prod_sandbox: true
         depends_on:
           - internal_qa
           - internal_qa_sandbox

--- a/azure/templates/sandbox-tests.yml
+++ b/azure/templates/sandbox-tests.yml
@@ -1,4 +1,4 @@
-paramters:
+parameters:
   - name: is_prod_sandbox
     displayName: Is the environment sandbox in prod?
     type: boolean

--- a/azure/templates/sandbox-tests.yml
+++ b/azure/templates/sandbox-tests.yml
@@ -18,7 +18,7 @@ steps:
   
   - ${{ if eq(parameters.is_prod_sandbox, false) }}:
     - bash: |
-        echo "#vso[task.setvariable variable=APIGEE_APP_ID;issecret=true]"
+        echo "##vso[task.setvariable variable=APIGEE_APP_ID;issecret=true]"
       displayName: Set APIGEE_APP_ID for non-prod sandbox env
 
     - task: Bash@3

--- a/azure/templates/sandbox-tests.yml
+++ b/azure/templates/sandbox-tests.yml
@@ -21,6 +21,13 @@ steps:
         echo "#vso[task.setvariable variable=APIGEE_APP_ID;issecret=true]"
       displayName: Set APIGEE_APP_ID for non-prod sandbox env
 
+    - task: Bash@3
+      displayName: Test APIGEE_APP_ID
+      inputs:
+        targetType: 'inline'
+        script: |
+          echo $(APIGEE_APP_ID)
+
   - bash: |
       export SERVICE_BASE_PATH="$(SERVICE_BASE_PATH)"
       export APIGEE_ENVIRONMENT="$(ENVIRONMENT)"

--- a/azure/templates/sandbox-tests.yml
+++ b/azure/templates/sandbox-tests.yml
@@ -9,13 +9,6 @@ steps:
     workingDirectory: $(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)
     displayName: Setup sandbox tests
 
-  - task: Bash@3
-    displayName: Find out what parameters.is_prod_sandbox is?
-    inputs:
-      targetType: 'inline'
-      script: |
-        echo ${{parameters.is_prod_sandbox}}
-
   - ${{ if eq(parameters.is_prod_sandbox, true) }}:
     - template: "azure/components/get-aws-secrets-and-ssm-params.yml@common"
       parameters:

--- a/azure/templates/sandbox-tests.yml
+++ b/azure/templates/sandbox-tests.yml
@@ -21,13 +21,6 @@ steps:
         echo "##vso[task.setvariable variable=APIGEE_APP_ID;issecret=true]"
       displayName: Set APIGEE_APP_ID for non-prod sandbox env
 
-    - task: Bash@3
-      displayName: Test APIGEE_APP_ID
-      inputs:
-        targetType: 'inline'
-        script: |
-          echo $(APIGEE_APP_ID)
-
   - bash: |
       export SERVICE_BASE_PATH="$(SERVICE_BASE_PATH)"
       export APIGEE_ENVIRONMENT="$(ENVIRONMENT)"

--- a/azure/templates/sandbox-tests.yml
+++ b/azure/templates/sandbox-tests.yml
@@ -3,6 +3,13 @@ steps:
     workingDirectory: $(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)
     displayName: Setup sandbox tests
 
+  - task: Bash@3
+    displayName: Find out what parameters.environment is?
+    inputs:
+      targetType: 'inline'
+      script: |
+        echo ${{parameters.environment}}
+
   - ${{ if eq(parameters.environment, 'sandbox') }}:
     - template: "azure/components/get-aws-secrets-and-ssm-params.yml@common"
       parameters:

--- a/azure/templates/sandbox-tests.yml
+++ b/azure/templates/sandbox-tests.yml
@@ -1,26 +1,32 @@
+paramters:
+  - name: is_prod_sandbox
+    displayName: Is the environment sandbox in prod?
+    type: boolean
+    default: false
+
 steps:
   - bash: poetry install
     workingDirectory: $(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)
     displayName: Setup sandbox tests
 
   - task: Bash@3
-    displayName: Find out what parameters.environment is?
+    displayName: Find out what parameters.is_prod_sandbox is?
     inputs:
       targetType: 'inline'
       script: |
-        echo ${{parameters.environment}}
+        echo ${{parameters.is_prod_sandbox}}
 
-  - ${{ if eq(parameters.environment, 'sandbox') }}:
+  - ${{ if eq(parameters.is_prod_sandbox, true) }}:
     - template: "azure/components/get-aws-secrets-and-ssm-params.yml@common"
       parameters:
         secret_ids:
           - ptl/azure-devops/personal-demographics/int/APIGEE_APP_ID
-      displayName: Set APIGEE_APP_ID for sandbox env
+      displayName: Set APIGEE_APP_ID for prod sandbox env
   
-  - ${{ if ne(parameters.environment, 'sandbox') }}:
+  - ${{ if eq(parameters.is_prod_sandbox, false) }}:
     - bash: |
         echo "#vso[task.setvariable variable=APIGEE_APP_ID;issecret=true]"
-      displayName: Set APIGEE_APP_ID for non-sandbox env
+      displayName: Set APIGEE_APP_ID for non-prod sandbox env
 
   - bash: |
       export SERVICE_BASE_PATH="$(SERVICE_BASE_PATH)"

--- a/tests/functional/features/application_restricted.feature
+++ b/tests/functional/features/application_restricted.feature
@@ -124,7 +124,7 @@ Feature: Unattended Access
     And I create a new app
     And I add the attribute with key of apim-app-flow-vars and a value of { "pds" : { "app-restricted": { "update": true } }}
     And I add the scope urn:nhsd:apim:app:level3:personal-demographics-service
-    And I wait for 200 milliseconds
+    And I wait for 500 milliseconds
     And I have a valid access token
 
     When I PATCH a patient
@@ -136,7 +136,7 @@ Feature: Unattended Access
     And I create a new app
     And I add the attribute with key of apim-app-flow-vars and a value of { "pds" : { "app-restricted": { "update": false } }}
     And I add the scope urn:nhsd:apim:app:level3:personal-demographics-service
-    And I wait for 100 milliseconds
+    And I wait for 500 milliseconds
     And I have a valid access token
 
     When I PATCH a patient
@@ -148,7 +148,7 @@ Feature: Unattended Access
     And I create a new app
     And I add the attribute with key of apim-app-flow-vars and a value of { "pds" : { "app-restricted": { "update": true } }}
     And I add the scope urn:nhsd:apim:app:level3:reasonable-adjustment-flag
-    And I wait for 200 milliseconds
+    And I wait for 500 milliseconds
     And I have a valid access token
 
     When I PATCH a patient
@@ -173,7 +173,7 @@ Feature: Unattended Access
     Given I am authenticating using unattended access
     And I have a request context
     And I create a new app
-    And I wait for 100 milliseconds
+    And I wait for 500 milliseconds
     And I have a valid access token
 
     When I GET a patient
@@ -185,7 +185,7 @@ Feature: Unattended Access
     And I have a request context
     And I create a new app
     And I add an asid attribute
-    And I wait for 200 milliseconds
+    And I wait for 500 milliseconds
     And I have a valid access token
 
     When I GET a patient


### PR DESCRIPTION
## Summary
The sandbox-tests.yml file needs an Apigee App ID when run in prod, and not when not. This is to correct the initial implementation of this made in PR 901.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
