### PR TITLE
Spinedem 1296 remove fixtures

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -65,8 +65,6 @@ extends:
         enable_status_monitoring: false
         post_deploy:
           - template: templates/sandbox-tests.yml
-            parameters:
-              is_prod_sandbox: true
         depends_on:
           - internal_qa
           - internal_qa_sandbox

--- a/azure/templates/sandbox-tests.yml
+++ b/azure/templates/sandbox-tests.yml
@@ -1,37 +1,15 @@
-parameters:
-  - name: is_prod_sandbox
-    type: boolean
-    default: false
-
 steps:
   - bash: poetry install
     workingDirectory: $(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)
     displayName: Setup sandbox tests
-
-  - ${{ if eq(parameters.is_prod_sandbox, true) }}:
-    - template: "azure/components/aws-assume-role.yml@common"
-      parameters:
-        role: "auto-ops"
-        profile: "apm_ptl"
-
-    - template: "azure/components/get-aws-secrets-and-ssm-params.yml@common"
-      parameters:
-        secret_ids:
-          - ptl/azure-devops/personal-demographics/int/APIGEE_APP_ID
-
-  - ${{ if eq(parameters.is_prod_sandbox, false) }}:
-    - bash: |
-        echo "##vso[task.setvariable variable=APIGEE_APP_ID;issecret=true]"
-      displayName: Set APIGEE_APP_ID for non-prod sandbox env
 
   - bash: |
       export SERVICE_BASE_PATH="$(SERVICE_BASE_PATH)"
       export APIGEE_ENVIRONMENT="$(ENVIRONMENT)"
       export SOURCE_COMMIT_ID=$(Build.SourceVersion)
       export STATUS_ENDPOINT_API_KEY="$(status-endpoint-api-key)"
-      export APIGEE_ACCESS_TOKEN="$(secret.AccessToken)"
 
-      poetry run pytest -v tests/sandbox/test_sandbox.py --junitxml=tests/sandbox-test-report.xml --reruns 3 --reruns-delay 1 --proxy-name "$(FULLY_QUALIFIED_SERVICE_NAME)" --apigee-app-id "$(APIGEE_APP_ID)"
+      poetry run pytest -v tests/sandbox/test_sandbox.py --junitxml=tests/sandbox-test-report.xml --reruns 3 --reruns-delay 1
     displayName: Run sandbox tests
     workingDirectory: "$(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,11 @@ import pytest
 pytest_plugins = ["pytest_nhsd_apim.apigee_edge",
                   "pytest_nhsd_apim.secrets"]
 
+
 @pytest.fixture()
 def status_endpoint_api_key():
     return os.environ.get('STATUS_ENDPOINT_API_KEY', 'not-set')
+
 
 @pytest.fixture()
 def status_endpoint_header(status_endpoint_api_key):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,13 @@
+import os
+import pytest
+
 pytest_plugins = ["pytest_nhsd_apim.apigee_edge",
                   "pytest_nhsd_apim.secrets"]
+
+@pytest.fixture()
+def status_endpoint_api_key():
+    return os.environ.get('STATUS_ENDPOINT_API_KEY', 'not-set')
+
+@pytest.fixture()
+def status_endpoint_header(status_endpoint_api_key):
+    return {"apikey": status_endpoint_api_key}

--- a/tests/sandbox/test_sandbox.py
+++ b/tests/sandbox/test_sandbox.py
@@ -32,7 +32,7 @@ class TestPDSSandboxDeploymentSuite:
     @pytest.mark.asyncio
     async def test_wait_for_status(self,
                                    commit_id: str,
-                                   status_endpoint_auth_headers: Dict[str, str]):
+                                   status_endpoint_header: Dict[str, str]):
         async def is_deployed(response: ClientResponse):
             if response.status != 200:
                 return False
@@ -48,7 +48,7 @@ class TestPDSSandboxDeploymentSuite:
             return backend.get("commitId") == commit_id
 
         await helpers.poll_until(url=f"{config.SANDBOX_BASE_URL}/_status",
-                                 headers=status_endpoint_auth_headers,
+                                 headers=status_endpoint_header,
                                  until=is_deployed,
                                  timeout=120)
 

--- a/tests/sandbox/test_sandbox.py
+++ b/tests/sandbox/test_sandbox.py
@@ -4,6 +4,7 @@ from .data.scenarios import relatedPerson, retrieve, search, update
 import requests
 from typing import Dict
 from .utils import helpers
+from .configuration import config
 
 
 @pytest.mark.deployment_scenarios
@@ -12,27 +13,25 @@ class TestPDSSandboxDeploymentSuite:
 
     @pytest.mark.asyncio
     async def test_wait_for_ping(self,
-                                 commit_id: str,
-                                 nhsd_apim_proxy_url: str):
+                                 commit_id: str):
         async def apigee_deployed(response: ClientResponse):
             if response.status != 200:
                 return False
             body = await response.json(content_type=None)
             return body.get("commitId") == commit_id
 
-        await helpers.poll_until(url=f"{nhsd_apim_proxy_url}/_ping",
+        await helpers.poll_until(url=f"{config.SANDBOX_BASE_URL}/_ping",
                                  until=apigee_deployed,
                                  timeout=30)
 
     @pytest.mark.asyncio
-    async def test_check_status_is_secured(self, nhsd_apim_proxy_url: str):
-        response = requests.get(f"{nhsd_apim_proxy_url}/_status")
+    async def test_check_status_is_secured(self):
+        response = requests.get(f"{config.SANDBOX_BASE_URL}/_status")
         assert response.status_code == 401
 
     @pytest.mark.asyncio
     async def test_wait_for_status(self,
                                    commit_id: str,
-                                   nhsd_apim_proxy_url: str,
                                    status_endpoint_auth_headers: Dict[str, str]):
         async def is_deployed(response: ClientResponse):
             if response.status != 200:
@@ -48,7 +47,7 @@ class TestPDSSandboxDeploymentSuite:
 
             return backend.get("commitId") == commit_id
 
-        await helpers.poll_until(url=f"{nhsd_apim_proxy_url}/_status",
+        await helpers.poll_until(url=f"{config.SANDBOX_BASE_URL}/_status",
                                  headers=status_endpoint_auth_headers,
                                  until=is_deployed,
                                  timeout=120)


### PR DESCRIPTION
## Summary
Remove fixtures previously implemented.

Given the pytest-nhsd-apim package is meant to be used for nhsd-nonprod Apigee orgs, ie all environments except int, sandbox, dev, and prod, and given that these sandbox tests are to be run against nhsd-prod sandbox, a simpler solution would be to use the already in-use `config.SANDBOX_BASE_URL` constant, which is Apigee org agnostic, instead of attempting to find the url through two different methods for the sandbox environments in nhsd-nonprod and nhsd-prod.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
