### PR TITLE
Remove assignment of unused env var.

### DIFF
--- a/tests/functional/configuration/config.py
+++ b/tests/functional/configuration/config.py
@@ -53,7 +53,6 @@ JWKS_RESOURCE_URL_ASID_REQUIRED_APP = ('https://raw.githubusercontent.com/NHSDig
                                        'e143bb5f-ce9d-4adf-b5b2-2f25ae380c66.json')
 
 # JWT keys
-ID_TOKEN_NHS_LOGIN_PRIVATE_KEY = ENV['nhs_login_private_key']
 JWT_PRIVATE_KEY_ABSOLUTE_PATH = ENV['jwt_private_key']
 
 AUTH_TOKEN_EXPIRY_MS = (


### PR DESCRIPTION
## Summary
Assignment of an unused/unset (was removed in PR 924's pds-test-int.yml) environment variable cause INT stage of Release pipeline to fail. 

As it is not used, and is no longer set in the pipeline, this change is to remove the error-raising variable assignment.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
