### PR TITLE
Spinedem 1680 move autouse fixture

### DIFF
--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -341,17 +341,6 @@ def add_proxies_to_products(products_api: ApiProductsAPI,
                                          body=patient_access_product)
 
 
-@pytest.fixture(autouse=True)
-def add_proxies_to_products_user_restricted(products_api: ApiProductsAPI,
-                                            nhsd_apim_proxy_name: str):
-    product_name = nhsd_apim_proxy_name.replace("-asid-required", "")
-
-    default_product = products_api.get_product_by_name(product_name=product_name)
-    if nhsd_apim_proxy_name not in default_product['proxies']:
-        default_product['proxies'].append(nhsd_apim_proxy_name)
-        products_api.put_product_by_name(product_name=product_name, body=default_product)
-
-
 def _set_default_rate_limit(product: ApigeeApiProducts, api_products):
     """Updates an Apigee Product with a default rate limit and quota.
 

--- a/tests/functional/test_proxy_behaviour.py
+++ b/tests/functional/test_proxy_behaviour.py
@@ -11,9 +11,7 @@ import pytest_bdd
 from .configuration.config import BASE_URL, PDS_BASE_PATH, TEST_PATIENT_ID
 import json
 from .utils.helpers import find_item_in_dict
-import logging
 
-LOGGER = logging.getLogger(__name__)
 
 scenario = partial(pytest_bdd.scenario, './features/proxy_behaviour.feature')
 

--- a/tests/functional/test_user_restricted.py
+++ b/tests/functional/test_user_restricted.py
@@ -13,7 +13,7 @@ from requests import Response
 import re
 import uuid
 from jsonpath_rw import parse
-
+from pytest_nhsd_apim.apigee_apis import ApiProductsAPI
 
 AUTH_HEALTHCARE_WORKER = {
         "api_name": "personal-demographics-service",
@@ -220,6 +220,17 @@ def test_ping():
 @status_scenario('Healthcheck endpoint')
 def test_healthcheck():
     pass
+
+
+@pytest.fixture(autouse=True)
+def add_proxies_to_products_user_restricted(products_api: ApiProductsAPI,
+                                            nhsd_apim_proxy_name: str):
+    product_name = nhsd_apim_proxy_name.replace("-asid-required", "")
+
+    default_product = products_api.get_product_by_name(product_name=product_name)
+    if nhsd_apim_proxy_name not in default_product['proxies']:
+        default_product['proxies'].append(nhsd_apim_proxy_name)
+        products_api.put_product_by_name(product_name=product_name, body=default_product)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
## Summary
An `autouse=True` fixture was being used in the INT environment when it should not have been. 


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
