### PR TITLE
SPINDEM-1819 - Add expired access token test to patient access mode

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,13 @@
 import os
 import pytest
 
-pytest_plugins = ["pytest_nhsd_apim.apigee_edge",
-                  "pytest_nhsd_apim.secrets"]
+pytest_plugins = [
+    "pytest_nhsd_apim.apigee_edge",
+    "pytest_nhsd_apim.secrets",
+    "tests.functional.steps.given",
+    "tests.functional.steps.when",
+    "tests.functional.steps.then"
+]
 
 
 @pytest.fixture()

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -229,19 +229,7 @@ def empty_header(headers_with_authorization: dict, field: str) -> dict:
 
 
 @given("I have an expired access token", target_fixture='headers_with_authorization')
-def add_expired_token_to_auth_header(headers_with_authorization: dict) -> dict:
-    claims = {
-        "sub": config.APPLICATION_RESTRICTED_API_KEY,
-        "iss": config.APPLICATION_RESTRICTED_API_KEY,
-        "jti": str(uuid.uuid4()),
-        "aud": f"{config.BASE_URL}/{config.OAUTH_PROXY}/token",
-        "exp": int(time.time()) + 300,
-    }
-
-    encoded_jwt = jwt.encode(
-        claims, config.SIGNING_KEY, algorithm="RS512", headers={"kid": config.KEY_ID}
-    )
-
+def add_expired_token_to_auth_header(headers_with_authorization: dict, encoded_jwt: dict) -> dict:
     response = post(
         f"{config.BASE_URL}/{config.OAUTH_PROXY}/token",
         data={
@@ -648,6 +636,24 @@ def create_random_date():
     year = random.randrange(1940, 2020)
     new_date = f"{year}-{month}-{day}"
     return new_date
+
+
+@pytest.fixture()
+def encoded_jwt():
+    claims = {
+        "sub": config.APPLICATION_RESTRICTED_API_KEY,
+        "iss": config.APPLICATION_RESTRICTED_API_KEY,
+        "jti": str(uuid.uuid4()),
+        "aud": f"{config.BASE_URL}/{config.OAUTH_PROXY}/token",
+        "exp": int(time.time()) + 300,
+    }
+
+    encoded_jwt = jwt.encode(claims,
+                             config.SIGNING_KEY,
+                             algorithm="RS512",
+                             headers={"kid": config.KEY_ID})
+
+    return encoded_jwt
 
 
 @pytest.fixture()

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -98,19 +98,6 @@ def provide_p9_auth_details(request) -> None:
     request.node.add_marker(pytest.mark.nhsd_apim_authorization(auth_details))
 
 
-@given('scope added to product')
-def add_scope_to_products_patient_access(products_api: ApiProductsAPI,
-                                         nhsd_apim_proxy_name: str,
-                                         nhsd_apim_authorization: dict):
-    product_name = nhsd_apim_proxy_name.replace("-asid-required", "")
-
-    default_product = products_api.get_product_by_name(product_name=product_name)
-    if nhsd_apim_authorization['scope'] not in default_product['scopes']:
-        default_product['scopes'].append(nhsd_apim_authorization['scope'])
-        products_api.put_product_by_name(product_name=product_name, body=default_product)
-        time.sleep(2)
-
-
 @given("I am a P5 user")
 def provide_p5_auth_details(request) -> None:
     auth_details = {

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -229,9 +229,11 @@ def empty_header(headers_with_authorization: dict, field: str) -> dict:
 
 
 @given("I have an expired access token", target_fixture='headers_with_authorization')
-def add_expired_token_to_auth_header(headers_with_authorization: dict, encoded_jwt: dict) -> dict:
+def add_expired_token_to_auth_header(headers_with_authorization: dict,
+                                     encoded_jwt: dict,
+                                     identity_service_base_url:str) -> dict:
     response = post(
-        f"{config.BASE_URL}/{config.OAUTH_PROXY}/token",
+        f"{identity_service_base_url}/token",
         data={
             "_access_token_expiry_ms": "1",
             "grant_type": "client_credentials",
@@ -639,12 +641,12 @@ def create_random_date():
 
 
 @pytest.fixture()
-def encoded_jwt():
+def encoded_jwt(identity_service_base_url: str):
     claims = {
         "sub": config.APPLICATION_RESTRICTED_API_KEY,
         "iss": config.APPLICATION_RESTRICTED_API_KEY,
         "jti": str(uuid.uuid4()),
-        "aud": f"{config.BASE_URL}/{config.OAUTH_PROXY}/token",
+        "aud": f"{identity_service_base_url}/token",
         "exp": int(time.time()) + 300,
     }
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -30,12 +30,6 @@ from pytest_nhsd_apim.apigee_apis import (
     DeveloperAppsAPI,
 )
 
-pytest_plugins = [
-    "tests.functional.steps.given",
-    "tests.functional.steps.when",
-    "tests.functional.steps.then",
-]
-
 FILE_DIR = os.path.dirname(__file__)
 RESPONSES_DIR = os.path.join(FILE_DIR, 'data', 'responses')
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -231,7 +231,7 @@ def empty_header(headers_with_authorization: dict, field: str) -> dict:
 @given("I have an expired access token", target_fixture='headers_with_authorization')
 def add_expired_token_to_auth_header(headers_with_authorization: dict,
                                      encoded_jwt: dict,
-                                     identity_service_base_url:str) -> dict:
+                                     identity_service_base_url: str) -> dict:
     response = post(
         f"{identity_service_base_url}/token",
         data={
@@ -271,20 +271,8 @@ def retrieve_related_person(headers_with_authorization: dict, nhs_number: str, p
 
 
 @when("I update the patient's PDS record", target_fixture='response')
-def update_patient(headers_with_authorization: dict, update: Update, pds_url: str) -> Response:
-    headers = headers_with_authorization
-    headers.update({
-        "Content-Type": "application/json-patch+json",
-        "If-Match": update.etag,
-    })
-
-    return patch(url=f"{pds_url}/Patient/{update.nhs_number}",
-                 headers=headers,
-                 json=update.patches)
-
-
 @when("I update another patient's PDS record", target_fixture='response')
-def update_another_patient(headers_with_authorization: dict, update: Update, pds_url: str) -> Response:
+def update_patient(headers_with_authorization: dict, update: Update, pds_url: str) -> Response:
     headers = headers_with_authorization
     headers.update({
         "Content-Type": "application/json-patch+json",
@@ -307,19 +295,6 @@ def update_patient_incorrect_path(headers_with_authorization: dict, update: Upda
     return patch(url=f"{pds_url}/Patient?family=Smith&gender=female&birthdate=eq2010-10-22",
                  headers=headers,
                  json=update.patches)
-
-
-@when("I update my own PDS record", target_fixture='response')
-def update_patient_self(headers_with_authorization: dict, update_self: Update, pds_url: str) -> Response:
-    headers = headers_with_authorization
-    headers.update({
-        "Content-Type": "application/json-patch+json",
-        "If-Match": update_self.etag,
-    })
-
-    return patch(url=f"{pds_url}/Patient/{update_self.nhs_number}",
-                 headers=headers,
-                 json=update_self.patches)
 
 
 @when(

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,9 +1,5 @@
 from tests.scripts.pds_request import GenericPdsRequestor, PdsRecord
 import pytest
-import os
-from pytest_bdd import given, when, then, parsers
-from jsonpath_rw import parse
-from pytest_check import check
 import urllib
 import uuid
 from .utils.apigee_api_apps import ApigeeApiDeveloperApps
@@ -11,19 +7,18 @@ from .utils.apigee_api_products import ApigeeApiProducts
 from .configuration import config
 from .configuration.config import BASE_URL, PDS_BASE_PATH
 import random
-from requests import Response, get, patch, post
+from requests import Response
 import json
 import jwt
 from typing import Union
-from .data.searches import Search
-from .data.updates import Update
-from .data import searches
-from .data import updates
-from .data import patients
-from .data.patients import Patient
-from copy import copy
-from tests.functional.utils.helpers import is_key_in_dict
+from tests.functional.data.searches import Search
+from tests.functional.data.updates import Update
+from tests.functional.data import searches
+from tests.functional.data import updates
+from tests.functional.data import patients
+from tests.functional.data.patients import Patient
 import time
+import os
 
 from pytest_nhsd_apim.identity_service import (
     ClientCredentialsConfig,
@@ -34,6 +29,12 @@ from pytest_nhsd_apim.apigee_apis import (
     ApiProductsAPI,
     DeveloperAppsAPI,
 )
+
+pytest_plugins = [
+    "tests.functional.steps.given",
+    "tests.functional.steps.when",
+    "tests.functional.steps.then",
+]
 
 FILE_DIR = os.path.dirname(__file__)
 RESPONSES_DIR = os.path.join(FILE_DIR, 'data', 'responses')
@@ -69,71 +70,6 @@ def add_asid_to_testapp(developer_apps_api,
         developer_apps_api.post_app_attributes(email=developer_email, app_name=app_name, body=data)
 
 
-@given("I am an unknown user", target_fixture='headers_with_authorization')
-def provide_headers_with_no_auth_details() -> None:
-    return {}
-
-
-@given("I am a healthcare worker")
-def provide_healthcare_worker_auth_details(request) -> None:
-    auth_details = {
-        "api_name": "personal-demographics-service",
-        "access": "healthcare_worker",
-        "level": "aal3",
-        "login_form": {"username": "656005750104"},
-        "force_new_token": True
-    }
-    request.node.add_marker(pytest.mark.nhsd_apim_authorization(auth_details))
-
-
-@given("I am a P9 user")
-def provide_p9_auth_details(request) -> None:
-    auth_details = {
-        "api_name": "personal-demographics-service",
-        "access": "patient",
-        "level": "P9",
-        "login_form": {"username": "9912003071"},
-        "force_new_token": True
-    }
-    request.node.add_marker(pytest.mark.nhsd_apim_authorization(auth_details))
-
-
-@given("I am a P5 user")
-def provide_p5_auth_details(request) -> None:
-    auth_details = {
-        "api_name": "personal-demographics-service",
-        "access": "patient",
-        "level": "P5",
-        "login_form": {"username": "9912003071"},
-        "force_new_token": True
-    }
-    request.node.add_marker(pytest.mark.nhsd_apim_authorization(auth_details))
-
-
-@given("I am a p5 user")
-def provide_p5_lower_case_auth_details(request) -> None:
-    auth_details = {
-        "api_name": "personal-demographics-service",
-        "access": "patient",
-        "level": "p5",
-        "login_form": {"username": "9912003071"},
-        "force_new_token": True
-    }
-    request.node.add_marker(pytest.mark.nhsd_apim_authorization(auth_details))
-
-
-@given("I am a P0 user")
-def provide_p0_auth_details(request) -> None:
-    auth_details = {
-        "api_name": "personal-demographics-service",
-        "access": "patient",
-        "level": "P0",
-        "login_form": {"username": "9912003071"},
-        "force_new_token": True
-    }
-    request.node.add_marker(pytest.mark.nhsd_apim_authorization(auth_details))
-
-
 @pytest.fixture()
 def search() -> Search:
     return searches.DEFAULT
@@ -144,19 +80,9 @@ def update() -> Update:
     return updates.DEFAULT
 
 
-@given("I enter a patient's vague demographic details", target_fixture='search')
-def vague_patient() -> Search:
-    return searches.VAGUE
-
-
 @pytest.fixture()
 def patient() -> Patient:
     return patients.DEFAULT
-
-
-@given('I have a patient with a related person', target_fixture='patient')
-def patient_with_a_related_person() -> Patient:
-    return patients.WITH_RELATED_PERSON
 
 
 @pytest.fixture()
@@ -164,260 +90,9 @@ def nhs_number(patient: Patient) -> str:
     return patient.nhs_number
 
 
-@given("I have a patient's record to update", target_fixture='record_to_update')
-def record_to_update(update: Update, headers_with_authorization: dict, pds_url: str) -> dict:
-    response = retrieve_patient(headers_with_authorization, update.nhs_number, pds_url)
-
-    update.record_to_update = json.loads(response.text)
-    update.etag = response.headers['Etag']
-
-    return update.record_to_update
-
-
-@given("I wish to update the patient's gender")
-def add_new_gender_to_patch(update: Update) -> None:
-    current_gender = update.record_to_update['gender']
-    new_gender = 'male' if current_gender == 'female' else 'female'
-    update.value = new_gender
-
-
-@given(
-    parsers.cfparse(
-        "I don't have {_:String} {header_field:String} header",
-        extra_types=dict(String=str)
-    ),
-    target_fixture='headers_with_authorization'
-)
-def remove_header(headers_with_authorization, header_field) -> dict:
-    headers_with_authorization.pop(header_field)
-    return headers_with_authorization
-
-
-@given(
-    parsers.cfparse(
-        'I have a header {field:String} value of "{value:String}"',
-        extra_types=dict(String=str)
-    ),
-    target_fixture='headers_with_authorization')
-def update_header(headers_with_authorization: dict, field: str, value: str) -> dict:
-    headers_with_authorization.update({field: value})
-    return headers_with_authorization
-
-
-@given(
-    parsers.cfparse(
-        "I have an empty {field:String} header",
-        extra_types=dict(String=str)
-    ),
-    target_fixture='headers_with_authorization')
-def empty_header(headers_with_authorization: dict, field: str) -> dict:
-    headers_with_authorization.update({field: ''})
-    return headers_with_authorization
-
-
-@given("I have an expired access token", target_fixture='headers_with_authorization')
-def add_expired_token_to_auth_header(headers_with_authorization: dict,
-                                     encoded_jwt: dict,
-                                     identity_service_base_url: str) -> dict:
-    response = post(
-        f"{identity_service_base_url}/token",
-        data={
-            "_access_token_expiry_ms": "1",
-            "grant_type": "client_credentials",
-            "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
-            "client_assertion": encoded_jwt,
-        },
-    )
-
-    assert response.status_code == 200, f'POST /token failed. Response:\n {response.text}'
-
-    response_json = response.json()
-    assert response_json["expires_in"] and int(response_json["expires_in"]) == 0
-
-    token_value = response_json['access_token']
-    headers_with_authorization.update({
-        'Authorization': f'Bearer {token_value}'
-    })
-    return headers_with_authorization
-
-
 @pytest.fixture
 def query_params(search: Search) -> str:
     return urllib.parse.urlencode(search.query)
-
-
-@when('I retrieve my details', target_fixture='response')
-@when('I retrieve a patient', target_fixture='response')
-def retrieve_patient(headers_with_authorization: dict, nhs_number: str, pds_url: str) -> Response:
-    return get(url=f"{pds_url}/Patient/{nhs_number}", headers=headers_with_authorization)
-
-
-@when('I retrieve their related person', target_fixture='response')
-def retrieve_related_person(headers_with_authorization: dict, nhs_number: str, pds_url: str) -> Response:
-    return get(url=f"{pds_url}/Patient/{nhs_number}/RelatedPerson", headers=headers_with_authorization)
-
-
-@when("I update the patient's PDS record", target_fixture='response')
-@when("I update another patient's PDS record", target_fixture='response')
-def update_patient(headers_with_authorization: dict, update: Update, pds_url: str) -> Response:
-    headers = headers_with_authorization
-    headers.update({
-        "Content-Type": "application/json-patch+json",
-        "If-Match": update.etag,
-    })
-
-    return patch(url=f"{pds_url}/Patient/{update.nhs_number}",
-                 headers=headers,
-                 json=update.patches)
-
-
-@when("I update another patient's PDS record using an incorrect path", target_fixture='response')
-def update_patient_incorrect_path(headers_with_authorization: dict, update: Update, pds_url: str) -> Response:
-    headers = headers_with_authorization
-    headers.update({
-        "Content-Type": "application/json-patch+json",
-        "If-Match": update.etag,
-    })
-
-    return patch(url=f"{pds_url}/Patient?family=Smith&gender=female&birthdate=eq2010-10-22",
-                 headers=headers,
-                 json=update.patches)
-
-
-@when(
-    parsers.cfparse(
-        "I hit the /{endpoint:String} endpoint",
-        extra_types=dict(String=str)
-    ),
-    target_fixture='response'
-)
-def hit_endpoint(headers_with_authorization: dict, pds_url: str, endpoint: str):
-    return get(url=f'{pds_url}/{endpoint}', headers=headers_with_authorization)
-
-
-@when(
-    parsers.cfparse(
-        'the query parameters contain {key:String} as {value:String}',
-        extra_types=dict(String=str)
-    ),
-    target_fixture='query_params',
-)
-def amended_query_params(search: Search, key: str, value: str) -> str:
-    query_params = copy(search.query)
-    query_params.append((key, value))
-    return urllib.parse.urlencode(query_params)
-
-
-@when("I search for a patient's PDS record", target_fixture='response')
-@when("I search for the patient's PDS record", target_fixture='response')
-def search_patient(headers_with_authorization: dict, query_params: str, pds_url: str) -> Response:
-    return get(url=f"{pds_url}/Patient?{query_params}", headers=headers_with_authorization)
-
-
-@then(
-    parsers.cfparse(
-        "I get a {expected_status:Number} HTTP response code",
-        extra_types=dict(Number=int)
-    )
-)
-def check_status(response: Response, expected_status: int) -> None:
-    with check:
-        assert response.status_code == expected_status
-
-
-@then(
-    parsers.cfparse(
-        'the response body is the {expected_response:String} response',
-        extra_types=dict(String=str)
-    )
-)
-def response_body_contains_error(response_body: dict, expected_response: str) -> None:
-    response_file = expected_response.replace(' ', '_').lower()
-    with open(os.path.join(RESPONSES_DIR, f'{response_file}.json'), 'r') as f:
-        expected_response_body = json.load(f)
-    assert response_body == expected_response_body
-
-
-@then(
-    parsers.cfparse(
-        '{value:String} is at {path:String} in the response body',
-        extra_types=dict(String=str)
-    ))
-def check_value_in_response_body_at_path(response_body: dict, value: str, path: str) -> None:
-    matches = parse(path).find(response_body)
-    with check:
-        assert matches, f'There are no matches for {value} at {path} in the response body'
-        for match in matches:
-            assert match.value == value, f'{match.value} is not the expected value, {value}, at {path}'
-
-
-@then('the response body contains the expected response')
-def response_body_as_expected(response_body: dict, patient: Patient) -> None:
-    assert response_body == patient.expected_response
-
-
-@then(
-    parsers.cfparse(
-        'the {header_field:String} response header matches the request',
-        extra_types=dict(String=str)
-    )
-)
-def check_header_value(response: Response,
-                       header_field: str,
-                       headers_with_authorization: dict) -> None:
-    with check:
-        assert response.headers[header_field] == headers_with_authorization[header_field]
-
-
-@then("the response body contains the patient's NHS number")
-def response_body_contains_given_id(response_body: dict, nhs_number: dict) -> None:
-    with check:
-        assert response_body["id"] == nhs_number
-        assert response_body["resourceType"] == "Patient"
-
-
-@then('the response body is the correct shape')
-def response_body_shape(response_body: Response) -> None:
-    with check:
-        assert response_body["address"] is not None
-        assert isinstance(response_body["address"], list)
-
-        assert response_body["birthDate"] is not None
-        assert isinstance(response_body["birthDate"], str)
-        assert len(response_body["birthDate"]) > 1
-
-        assert response_body["gender"] is not None
-        assert isinstance(response_body["gender"], str)
-
-        assert response_body["name"] is not None
-        assert isinstance(response_body["name"], list)
-        assert len(response_body["name"]) > 0
-
-        assert len(response_body["identifier"]) > 0
-        assert isinstance(response_body["identifier"], list)
-
-        assert response_body["meta"] is not None
-
-
-@then('the response body contains the expected values')
-def check_expected_search_response_body(response_body: dict, search: Search) -> None:
-    with check:
-        for field in search.expected_response_fields:
-            matches = parse(field.path).find(response_body)
-            assert matches, f'There are no matches for {field.expected_value} at {field.path} in the response body'
-            for match in matches:
-                assert match.value == field.expected_value,\
-                    f'{field.path} in response does not contain the expected value, {field.expected_value}'
-
-
-@then('the response body does not contain sensitive fields')
-def check_sensitive_fields_are_absent(response_body: dict) -> None:
-    _sensitive_fields = ['address',
-                         'telecom',
-                         'generalPractitioner']
-    with check:
-        for field in _sensitive_fields:
-            assert not is_key_in_dict(response_body, field), f'Sensitive field, {field}, in response.'
 
 
 @pytest.fixture()

--- a/tests/functional/data/users.py
+++ b/tests/functional/data/users.py
@@ -1,0 +1,63 @@
+from typing import Dict
+
+
+class UserDirectory:
+    healthcare_worker = {
+        "level": "aal3",
+        "login_form": {"username": "656005750104"},
+    }
+
+    P9 = {
+            "login_form": {"username": "9912003071"},
+        }
+
+    P5 = {
+        "login_form": {"username": "9912003071"},
+    }
+
+    p5 = {
+        "level": "p5",
+        "login_form": {"username": "9912003071"},
+    }
+
+    P0 = {
+        "login_form": {"username": "9912003071"},
+    }
+
+    def __getitem__(self, key: str) -> Dict[str, str]:
+        user = getattr(self, key)
+
+        auth_details = {}
+        self.set_api_name(user, key, auth_details)
+        self.set_access(user, key, auth_details)
+        self.set_level(user, key, auth_details)
+        self.set_login_form(user, key, auth_details)
+        self.set_force_new_token(user, key, auth_details)
+
+        return auth_details
+
+    def set_api_name(self, user: dict, key: str, auth_details: Dict[str, str]) -> None:
+        api_name = user.get('api_name')
+        auth_details['api_name'] = api_name if api_name else 'personal-demographics-service'
+
+    def set_access(self, user: dict, key: str, auth_details: Dict[str, str]) -> None:
+        access = user.get('access')
+        if access:
+            auth_details['access'] = access
+        elif key.lower().startswith('p'):
+            auth_details['access'] = 'patient'
+        else:
+            auth_details['access'] = key
+
+    def set_level(self, user: dict, key: str, auth_details: Dict[str, str]) -> None:
+        level = user.get('level')
+        auth_details['level'] = level if level else key
+
+    def set_login_form(self, user: dict, key: str, auth_details: Dict[str, str]) -> None:
+        login_form = user.get('login_form')
+        if login_form:
+            auth_details['login_form'] = login_form
+
+    def set_force_new_token(self, user: dict, key: str, auth_details: Dict[str, str]) -> None:
+        force_new_token = user.get('force_new_token')
+        auth_details['force_new_token'] = force_new_token if force_new_token else True

--- a/tests/functional/features/healthcare_worker_retrieve.feature
+++ b/tests/functional/features/healthcare_worker_retrieve.feature
@@ -2,7 +2,7 @@ Feature: Healthcare Worker Access (Retrieve)
     Retrieve a PDS record as a healthcare worker
 
     Scenario: Healthcare worker using deprecated url
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I am using the deprecated url
 
         When I retrieve a patient
@@ -10,7 +10,7 @@ Feature: Healthcare Worker Access (Retrieve)
         Then I get a 404 HTTP response code
     
     Scenario: Healthcare worker can retrieve patient
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
 
         When I retrieve a patient
 
@@ -21,7 +21,7 @@ Feature: Healthcare Worker Access (Retrieve)
         And the response body is the correct shape
 
     Scenario: Attempt to retrieve a patient with missing authorization header
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I don't have an Authorization header
 
         When I retrieve a patient
@@ -33,7 +33,7 @@ Feature: Healthcare Worker Access (Retrieve)
         And the response body is the Missing Authorization header response
 
     Scenario: Attempt to retrieve a patient with an empty authorization header
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have an empty Authorization header
 
         When I retrieve a patient
@@ -45,7 +45,7 @@ Feature: Healthcare Worker Access (Retrieve)
         And the response body is the Empty Authorization header response
 
     Scenario: Attempt to retrieve a patient with an invalid authorization header
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a header Authorization value of "Bearer abcdef123456789"
 
         When I retrieve a patient
@@ -57,7 +57,7 @@ Feature: Healthcare Worker Access (Retrieve)
         And the response body is the Invalid Access Token response
 
     Scenario: Attempt to retrieve a patient without stating a role
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I don't have a NHSD-Session-URID header
 
         When I retrieve a patient
@@ -69,7 +69,7 @@ Feature: Healthcare Worker Access (Retrieve)
         And the response body is the Missing URID header response
 
     Scenario: Attempt to retrieve a patient with an invalid role
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a header NHSD-Session-URID value of "invalid"
 
         When I retrieve a patient
@@ -81,7 +81,7 @@ Feature: Healthcare Worker Access (Retrieve)
         And the response body is the Invalid URID header response
 
     Scenario: Attempt to retrieve a patient without Request ID header
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have an empty X-Request-ID header
 
         When I retrieve a patient
@@ -93,7 +93,7 @@ Feature: Healthcare Worker Access (Retrieve)
         And the response body is the Empty X-Request ID response
 
     Scenario: Attempt to retrieve a patient with an invalid X-Request-ID
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a header X-Request-ID value of "1234"
 
         When I retrieve a patient
@@ -105,7 +105,7 @@ Feature: Healthcare Worker Access (Retrieve)
         And the response body is the Invalid X-Request ID response
 
     Scenario: Attempt to retrieve a patient with a missing X-Request-ID
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I don't have a X-Request-ID header
 
         When I retrieve a patient

--- a/tests/functional/features/healthcare_worker_search.feature
+++ b/tests/functional/features/healthcare_worker_search.feature
@@ -2,7 +2,7 @@ Feature: Healthcare Worker Access (Search)
     Search for a PDS record as a healthcare worker
 
     Scenario: Healthcare worker can search for patient
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         
         When I search for the patient's PDS record
 
@@ -12,7 +12,7 @@ Feature: Healthcare Worker Access (Search)
         And the response body contains the expected values
 
     Scenario: Attempt to search for a patient with missing authorization header
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I don't have an Authorization header
 
         When I search for the patient's PDS record
@@ -24,7 +24,7 @@ Feature: Healthcare Worker Access (Search)
         And the response body does not contain id
 
     Scenario: Attempt to search for a patient with an empty authorization header
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have an empty Authorization header
 
         When I search for the patient's PDS record
@@ -36,7 +36,7 @@ Feature: Healthcare Worker Access (Search)
         And the response body is the Empty Authorization header response
 
     Scenario: Attempt to search for a patient with an invalid authorization header
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a header Authorization value of "Bearer abcdef123456789"
 
         When I search for the patient's PDS record
@@ -48,7 +48,7 @@ Feature: Healthcare Worker Access (Search)
         And the response body is the Invalid Access Token response
 
     Scenario: Attempt to search for a patient with an empty Request ID header
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have an empty X-Request-ID header
 
         When I search for the patient's PDS record
@@ -60,7 +60,7 @@ Feature: Healthcare Worker Access (Search)
         And the response body is the Empty X-Request ID response
 
     Scenario: Attempt to search for a patient with an invalid X-Request-ID
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a header X-Request-ID value of "1234"
 
         When I search for the patient's PDS record
@@ -72,7 +72,7 @@ Feature: Healthcare Worker Access (Search)
         And the response body is the Invalid X-Request ID response
 
     Scenario: Attempt to search for a patient with a missing X-Request-ID
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I don't have a X-Request-ID header
 
         When I search for the patient's PDS record
@@ -84,7 +84,7 @@ Feature: Healthcare Worker Access (Search)
         And the response body is the Missing X-Request ID response
 
     Scenario: Healthcare worker searches for sensitive patient
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a sensitive patient's demographic details
 
         When I search for the patient's PDS record
@@ -95,7 +95,7 @@ Feature: Healthcare Worker Access (Search)
         And the response body does not contain sensitive fields
 
     Scenario: Healthcare worker searches for patient without specifying gender
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a patient's demographic details without gender
 
         When I search for the patient's PDS record
@@ -104,7 +104,7 @@ Feature: Healthcare Worker Access (Search)
         And the response body contains the expected values
 
     Scenario: Healthcare worker searches for a patient with range for date of birth
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a patient's demographic details with a date of birth range
 
         When I search for the patient's PDS record
@@ -113,7 +113,7 @@ Feature: Healthcare Worker Access (Search)
         And the response body contains the expected values
 
     Scenario: Searching without gender can return mutliple results
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I enter a patient's vague demographic details
 
         When I search for the patient's PDS record
@@ -122,7 +122,7 @@ Feature: Healthcare Worker Access (Search)
         And the response body contains the expected values
 
     Scenario: Searching with fuzzy match
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I enter a patient's demographic details that match the fuzzy search criteria
 
         When the query parameters contain _fuzzy-match as true
@@ -132,7 +132,7 @@ Feature: Healthcare Worker Access (Search)
         And the response body contains the expected values
 
     Scenario: Searching with unicode returns unicode record
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I enter a patient's unicode demographic details
 
         When I search for the patient's PDS record
@@ -141,7 +141,7 @@ Feature: Healthcare Worker Access (Search)
         And the response body contains the expected values
 
     Scenario: Searching with specified results limit can return error
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I enter a patient's vague demographic details
 
         When the query parameters contain _max-results as 1
@@ -151,7 +151,7 @@ Feature: Healthcare Worker Access (Search)
         And the response body is the Too Many Matches response
 
     Scenario: Search returns an empty bundle
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I enter a patient's demographic details incorrectly
 
         When I search for the patient's PDS record

--- a/tests/functional/features/healthcare_worker_update.feature
+++ b/tests/functional/features/healthcare_worker_update.feature
@@ -2,7 +2,7 @@ Feature: Healthcare Worker Access (Update)
     Update a PDS record as a healthcare worker
     
     Scenario: Update patient
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a patient's record to update
         And I wish to update the patient's gender
 
@@ -13,7 +13,7 @@ Feature: Healthcare Worker Access (Update)
         And the response body contains the record's new version number
 
     Scenario: Update patient using deprecated respond-async still returns 200
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a patient's record to update
         And I wish to update the patient's gender
         And I have a header Prefer value of "respond-async"
@@ -25,7 +25,7 @@ Feature: Healthcare Worker Access (Update)
         And the response body contains the record's new version number
 
     Scenario: Update patient with invalid wait header still updates
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a patient's record to update
         And I wish to update the patient's gender
         And I have a header X-Sync-Wait value of "invalid"
@@ -37,7 +37,7 @@ Feature: Healthcare Worker Access (Update)
         And the response body contains the record's new version number
 
     Scenario: Update patient with low wait header
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a patient's record to update
         And I wish to update the patient's gender
         And I have a header X-Sync-Wait value of "0.25"
@@ -47,7 +47,7 @@ Feature: Healthcare Worker Access (Update)
         Then I get a 503 HTTP response code
 
     Scenario: Update patient with missing Authorization header
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a patient's record to update
         And I wish to update the patient's gender
         And I don't have a Authorization header
@@ -60,7 +60,7 @@ Feature: Healthcare Worker Access (Update)
         And the response body is the Missing Authorization header response
 
     Scenario: Update patient with an empty authorization header
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a patient's record to update
         And I wish to update the patient's gender
         And I have an empty Authorization header
@@ -73,7 +73,7 @@ Feature: Healthcare Worker Access (Update)
         And the response body is the Empty Authorization header response
 
     Scenario: Update patient with an invalid authorization header
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a patient's record to update
         And I wish to update the patient's gender
         And I have a header Authorization value of "Bearer abcdef123456789"
@@ -86,7 +86,7 @@ Feature: Healthcare Worker Access (Update)
         And the response body is the Invalid Access Token response
 
     Scenario: Update patient with an empty Request ID header
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a patient's record to update
         And I wish to update the patient's gender
         And I have an empty X-Request-ID header
@@ -99,7 +99,7 @@ Feature: Healthcare Worker Access (Update)
         And the response body is the Empty X-Request ID response
 
     Scenario: Update patient with an invalid X-Request-ID
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a patient's record to update
         And I wish to update the patient's gender
         And I have a header X-Request-ID value of "1234"
@@ -112,7 +112,7 @@ Feature: Healthcare Worker Access (Update)
         And the response body is the Invalid X-Request ID response
 
     Scenario: Update patient with a missing X-Request-ID
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a patient's record to update
         And I wish to update the patient's gender
         And I don't have a X-Request-ID header

--- a/tests/functional/features/patient_access_retrieve.feature
+++ b/tests/functional/features/patient_access_retrieve.feature
@@ -3,6 +3,7 @@ Feature: Patient Access (Retrieve)
 
 	Scenario: Patient can retrieve self
 		Given I am a P9 user
+		And scope added to product
 		
 		When I retrieve my details
 
@@ -10,6 +11,7 @@ Feature: Patient Access (Retrieve)
 
 	Scenario: Patient cannot retrieve another patient
 		Given I am a P9 user
+		And scope added to product
 		And I have another patient's NHS number
 		
 		When I retrieve a patient
@@ -20,6 +22,7 @@ Feature: Patient Access (Retrieve)
 
 	Scenario: Patient retrieve uses incorrect path
 		Given I am a P9 user
+		And scope added to product
 		
 		When I search for a patient's PDS record
 
@@ -29,6 +32,7 @@ Feature: Patient Access (Retrieve)
 
 	Scenario: Patient cannot retrieve their record with an expired token
 		Given I am a P9 user
+		And scope added to product
 		And I have an expired access token
 
 		When I retrieve my details

--- a/tests/functional/features/patient_access_retrieve.feature
+++ b/tests/functional/features/patient_access_retrieve.feature
@@ -3,7 +3,6 @@ Feature: Patient Access (Retrieve)
 
 	Scenario: Patient can retrieve self
 		Given I am a P9 user
-		And scope added to product
 		
 		When I retrieve my details
 
@@ -12,7 +11,6 @@ Feature: Patient Access (Retrieve)
 	Scenario: Patient cannot retrieve another patient
 		Given I am a P9 user
 		And I have another patient's NHS number
-		And scope added to product
 		
 		When I retrieve a patient
 
@@ -22,7 +20,6 @@ Feature: Patient Access (Retrieve)
 
 	Scenario: Patient retrieve uses incorrect path
 		Given I am a P9 user
-		And scope added to product
 		
 		When I search for a patient's PDS record
 
@@ -32,7 +29,6 @@ Feature: Patient Access (Retrieve)
 
 	Scenario: Patient cannot retrieve their record with an expired token
 		Given I am a P9 user
-		And scope added to product
 		And I have an expired access token
 
 		When I retrieve my details

--- a/tests/functional/features/patient_access_retrieve.feature
+++ b/tests/functional/features/patient_access_retrieve.feature
@@ -29,3 +29,14 @@ Feature: Patient Access (Retrieve)
 		Then I get a 403 HTTP response code
 		And ACCESS_DENIED is at issue[0].details.coding[0].code in the response body
 		And Patient cannot perform this action is at issue[0].details.coding[0].display in the response body
+
+	Scenario: Patient cannot retrieve their record with an expired token
+		Given I am a P9 user
+		And scope added to product
+		And I have an expired access token
+
+		When I retrieve my details
+
+		Then I get a 401 HTTP response code
+		And ACCESS_DENIED is at issue[0].details.coding[0].code in the response body
+		And Access Token expired is at issue[0].diagnostics in the response body

--- a/tests/functional/features/patient_access_update.feature
+++ b/tests/functional/features/patient_access_update.feature
@@ -3,7 +3,6 @@ Feature: Patient Access (Update)
 
 	Scenario: Patient cannot update another patient
 		Given I am a P9 user
-		And scope added to product
 
 		When I update another patient's PDS record
 
@@ -12,7 +11,6 @@ Feature: Patient Access (Update)
  
 	Scenario: Patient update uses incorrect path
 		Given I am a P9 user
-		And scope added to product
 
 		When I update another patient's PDS record using an incorrect path
 

--- a/tests/functional/features/patient_access_update.feature
+++ b/tests/functional/features/patient_access_update.feature
@@ -3,6 +3,7 @@ Feature: Patient Access (Update)
 
 	Scenario: Patient cannot update another patient
 		Given I am a P9 user
+		And scope added to product
 
 		When I update another patient's PDS record
 
@@ -11,6 +12,7 @@ Feature: Patient Access (Update)
  
 	Scenario: Patient update uses incorrect path
 		Given I am a P9 user
+		And scope added to product
 
 		When I update another patient's PDS record using an incorrect path
 

--- a/tests/functional/features/related_person.feature
+++ b/tests/functional/features/related_person.feature
@@ -2,7 +2,7 @@ Feature: Related Person endpoint
     Access a patient's related person
 
     Scenario: Retrieve a related person
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
         And I have a patient with a related person
 
         When I retrieve their related person

--- a/tests/functional/features/status_endpoints.feature
+++ b/tests/functional/features/status_endpoints.feature
@@ -9,7 +9,7 @@ Feature: Status endpoint
         Then I get a 200 HTTP response code
 
     Scenario: Healthcheck endpoint
-        Given I am a healthcare worker
+        Given I am a healthcare worker user
 
         When I hit the /healthcheck endpoint
 

--- a/tests/functional/steps/given.py
+++ b/tests/functional/steps/given.py
@@ -7,7 +7,22 @@ from tests.functional.data.patients import Patient
 from tests.functional.data.searches import Search
 from tests.functional.data.updates import Update
 from tests.functional.steps.when import retrieve_patient
+from pytest_nhsd_apim.apigee_apis import ApiProductsAPI
 import json
+import time
+
+
+@given('scope added to product')
+def add_scope_to_products_patient_access(products_api: ApiProductsAPI,
+                                         nhsd_apim_proxy_name: str,
+                                         nhsd_apim_authorization: dict):
+    product_name = nhsd_apim_proxy_name.replace("-asid-required", "")
+
+    default_product = products_api.get_product_by_name(product_name=product_name)
+    if nhsd_apim_authorization['scope'] not in default_product['scopes']:
+        default_product['scopes'].append(nhsd_apim_authorization['scope'])
+        products_api.put_product_by_name(product_name=product_name, body=default_product)
+        time.sleep(2)
 
 
 @given('I have a patient with a related person', target_fixture='patient')

--- a/tests/functional/steps/given.py
+++ b/tests/functional/steps/given.py
@@ -1,0 +1,162 @@
+import pytest
+from pytest_bdd import given, parsers
+from requests import post
+from tests.functional.data import searches
+from tests.functional.data import patients
+from tests.functional.data.patients import Patient
+from tests.functional.data.searches import Search
+from tests.functional.data.updates import Update
+from tests.functional.steps.when import retrieve_patient
+import json
+
+
+@given('I have a patient with a related person', target_fixture='patient')
+def patient_with_a_related_person() -> Patient:
+    return patients.WITH_RELATED_PERSON
+
+
+@given("I enter a patient's vague demographic details", target_fixture='search')
+def vague_patient() -> Search:
+    return searches.VAGUE
+
+
+@given("I am an unknown user", target_fixture='headers_with_authorization')
+def provide_headers_with_no_auth_details() -> None:
+    return {}
+
+
+@given("I am a healthcare worker")
+def provide_healthcare_worker_auth_details(request) -> None:
+    auth_details = {
+        "api_name": "personal-demographics-service",
+        "access": "healthcare_worker",
+        "level": "aal3",
+        "login_form": {"username": "656005750104"},
+        "force_new_token": True
+    }
+    request.node.add_marker(pytest.mark.nhsd_apim_authorization(auth_details))
+
+
+@given("I am a P9 user")
+def provide_p9_auth_details(request) -> None:
+    auth_details = {
+        "api_name": "personal-demographics-service",
+        "access": "patient",
+        "level": "P9",
+        "login_form": {"username": "9912003071"},
+        "force_new_token": True
+    }
+    request.node.add_marker(pytest.mark.nhsd_apim_authorization(auth_details))
+
+
+@given("I am a P5 user")
+def provide_p5_auth_details(request) -> None:
+    auth_details = {
+        "api_name": "personal-demographics-service",
+        "access": "patient",
+        "level": "P5",
+        "login_form": {"username": "9912003071"},
+        "force_new_token": True
+    }
+    request.node.add_marker(pytest.mark.nhsd_apim_authorization(auth_details))
+
+
+@given("I am a p5 user")
+def provide_p5_lower_case_auth_details(request) -> None:
+    auth_details = {
+        "api_name": "personal-demographics-service",
+        "access": "patient",
+        "level": "p5",
+        "login_form": {"username": "9912003071"},
+        "force_new_token": True
+    }
+    request.node.add_marker(pytest.mark.nhsd_apim_authorization(auth_details))
+
+
+@given("I am a P0 user")
+def provide_p0_auth_details(request) -> None:
+    auth_details = {
+        "api_name": "personal-demographics-service",
+        "access": "patient",
+        "level": "P0",
+        "login_form": {"username": "9912003071"},
+        "force_new_token": True
+    }
+    request.node.add_marker(pytest.mark.nhsd_apim_authorization(auth_details))
+
+
+@given("I have a patient's record to update", target_fixture='record_to_update')
+def record_to_update(update: Update, headers_with_authorization: dict, pds_url: str) -> dict:
+    response = retrieve_patient(headers_with_authorization, update.nhs_number, pds_url)
+
+    update.record_to_update = json.loads(response.text)
+    update.etag = response.headers['Etag']
+
+    return update.record_to_update
+
+
+@given("I wish to update the patient's gender")
+def add_new_gender_to_patch(update: Update) -> None:
+    current_gender = update.record_to_update['gender']
+    new_gender = 'male' if current_gender == 'female' else 'female'
+    update.value = new_gender
+
+
+@given(
+    parsers.cfparse(
+        "I don't have {_:String} {header_field:String} header",
+        extra_types=dict(String=str)
+    ),
+    target_fixture='headers_with_authorization'
+)
+def remove_header(headers_with_authorization, header_field) -> dict:
+    headers_with_authorization.pop(header_field)
+    return headers_with_authorization
+
+
+@given(
+    parsers.cfparse(
+        'I have a header {field:String} value of "{value:String}"',
+        extra_types=dict(String=str)
+    ),
+    target_fixture='headers_with_authorization')
+def update_header(headers_with_authorization: dict, field: str, value: str) -> dict:
+    headers_with_authorization.update({field: value})
+    return headers_with_authorization
+
+
+@given(
+    parsers.cfparse(
+        "I have an empty {field:String} header",
+        extra_types=dict(String=str)
+    ),
+    target_fixture='headers_with_authorization')
+def empty_header(headers_with_authorization: dict, field: str) -> dict:
+    headers_with_authorization.update({field: ''})
+    return headers_with_authorization
+
+
+@given("I have an expired access token", target_fixture='headers_with_authorization')
+def add_expired_token_to_auth_header(headers_with_authorization: dict,
+                                     encoded_jwt: dict,
+                                     identity_service_base_url: str) -> dict:
+    response = post(
+        f"{identity_service_base_url}/token",
+        data={
+            "_access_token_expiry_ms": "1",
+            "grant_type": "client_credentials",
+            "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            "client_assertion": encoded_jwt,
+        },
+    )
+
+    assert response.status_code == 200, f'POST /token failed. Response:\n {response.text}'
+
+    response_json = response.json()
+    assert response_json["expires_in"] and int(response_json["expires_in"]) == 0
+
+    token_value = response_json['access_token']
+    headers_with_authorization.update({
+        'Authorization': f'Bearer {token_value}'
+    })
+    return headers_with_authorization

--- a/tests/functional/steps/given.py
+++ b/tests/functional/steps/given.py
@@ -1,8 +1,10 @@
 import pytest
+from pytest import FixtureRequest
 from pytest_bdd import given, parsers
 from requests import post
 from tests.functional.data import searches
 from tests.functional.data import patients
+from tests.functional.data.users import UserDirectory
 from tests.functional.data.patients import Patient
 from tests.functional.data.searches import Search
 from tests.functional.data.updates import Update
@@ -53,63 +55,18 @@ def provide_headers_with_no_auth_details() -> None:
     return {}
 
 
-@given("I am a healthcare worker")
-def provide_healthcare_worker_auth_details(request) -> None:
-    auth_details = {
-        "api_name": "personal-demographics-service",
-        "access": "healthcare_worker",
-        "level": "aal3",
-        "login_form": {"username": "656005750104"},
-        "force_new_token": True
-    }
-    request.node.add_marker(pytest.mark.nhsd_apim_authorization(auth_details))
+@pytest.fixture(scope='session')
+def user_directory() -> UserDirectory:
+    return UserDirectory()
 
 
-@given("I am a P9 user")
-def provide_p9_auth_details(request) -> None:
-    auth_details = {
-        "api_name": "personal-demographics-service",
-        "access": "patient",
-        "level": "P9",
-        "login_form": {"username": "9912003071"},
-        "force_new_token": True
-    }
-    request.node.add_marker(pytest.mark.nhsd_apim_authorization(auth_details))
-
-
-@given("I am a P5 user")
-def provide_p5_auth_details(request) -> None:
-    auth_details = {
-        "api_name": "personal-demographics-service",
-        "access": "patient",
-        "level": "P5",
-        "login_form": {"username": "9912003071"},
-        "force_new_token": True
-    }
-    request.node.add_marker(pytest.mark.nhsd_apim_authorization(auth_details))
-
-
-@given("I am a p5 user")
-def provide_p5_lower_case_auth_details(request) -> None:
-    auth_details = {
-        "api_name": "personal-demographics-service",
-        "access": "patient",
-        "level": "p5",
-        "login_form": {"username": "9912003071"},
-        "force_new_token": True
-    }
-    request.node.add_marker(pytest.mark.nhsd_apim_authorization(auth_details))
-
-
-@given("I am a P0 user")
-def provide_p0_auth_details(request) -> None:
-    auth_details = {
-        "api_name": "personal-demographics-service",
-        "access": "patient",
-        "level": "P0",
-        "login_form": {"username": "9912003071"},
-        "force_new_token": True
-    }
+@given(
+    parsers.cfparse(
+        "I am a {user_name:String} user",
+        extra_types=dict(String=str)
+    ))
+def add_auth_marker(request: FixtureRequest, user_name: str, user_directory: UserDirectory) -> None:
+    auth_details = user_directory[user_name.replace(' ', '_')]
     request.node.add_marker(pytest.mark.nhsd_apim_authorization(auth_details))
 
 

--- a/tests/functional/steps/then.py
+++ b/tests/functional/steps/then.py
@@ -1,0 +1,116 @@
+from pytest_check import check
+from pytest_bdd import then, parsers
+from jsonpath_rw import parse
+from requests import Response
+import os
+import json
+from tests.functional.data.patients import Patient
+from tests.functional.data.searches import Search
+from tests.functional.utils.helpers import is_key_in_dict
+from tests.functional.conftest import RESPONSES_DIR
+
+
+@then(
+    parsers.cfparse(
+        "I get a {expected_status:Number} HTTP response code",
+        extra_types=dict(Number=int)
+    )
+)
+def check_status(response: Response, expected_status: int) -> None:
+    with check:
+        assert response.status_code == expected_status
+
+
+@then(
+    parsers.cfparse(
+        'the response body is the {expected_response:String} response',
+        extra_types=dict(String=str)
+    )
+)
+def response_body_contains_error(response_body: dict, expected_response: str) -> None:
+    response_file = expected_response.replace(' ', '_').lower()
+    with open(os.path.join(RESPONSES_DIR, f'{response_file}.json'), 'r') as f:
+        expected_response_body = json.load(f)
+    assert response_body == expected_response_body
+
+
+@then(
+    parsers.cfparse(
+        '{value:String} is at {path:String} in the response body',
+        extra_types=dict(String=str)
+    ))
+def check_value_in_response_body_at_path(response_body: dict, value: str, path: str) -> None:
+    matches = parse(path).find(response_body)
+    with check:
+        assert matches, f'There are no matches for {value} at {path} in the response body'
+        for match in matches:
+            assert match.value == value, f'{match.value} is not the expected value, {value}, at {path}'
+
+
+@then('the response body contains the expected response')
+def response_body_as_expected(response_body: dict, patient: Patient) -> None:
+    assert response_body == patient.expected_response
+
+
+@then(
+    parsers.cfparse(
+        'the {header_field:String} response header matches the request',
+        extra_types=dict(String=str)
+    )
+)
+def check_header_value(response: Response,
+                       header_field: str,
+                       headers_with_authorization: dict) -> None:
+    with check:
+        assert response.headers[header_field] == headers_with_authorization[header_field]
+
+
+@then("the response body contains the patient's NHS number")
+def response_body_contains_given_id(response_body: dict, nhs_number: dict) -> None:
+    with check:
+        assert response_body["id"] == nhs_number
+        assert response_body["resourceType"] == "Patient"
+
+
+@then('the response body is the correct shape')
+def response_body_shape(response_body: Response) -> None:
+    with check:
+        assert response_body["address"] is not None
+        assert isinstance(response_body["address"], list)
+
+        assert response_body["birthDate"] is not None
+        assert isinstance(response_body["birthDate"], str)
+        assert len(response_body["birthDate"]) > 1
+
+        assert response_body["gender"] is not None
+        assert isinstance(response_body["gender"], str)
+
+        assert response_body["name"] is not None
+        assert isinstance(response_body["name"], list)
+        assert len(response_body["name"]) > 0
+
+        assert len(response_body["identifier"]) > 0
+        assert isinstance(response_body["identifier"], list)
+
+        assert response_body["meta"] is not None
+
+
+@then('the response body contains the expected values')
+def check_expected_search_response_body(response_body: dict, search: Search) -> None:
+    with check:
+        for field in search.expected_response_fields:
+            matches = parse(field.path).find(response_body)
+            assert matches, f'There are no matches for {field.expected_value} at {field.path} in the response body'
+            for match in matches:
+                assert match.value == field.expected_value,\
+                    f'{field.path} in response does not contain the expected value, {field.expected_value}'
+
+
+@then('the response body does not contain sensitive fields')
+def check_sensitive_fields_are_absent(response_body: dict) -> None:
+    _sensitive_fields = ['address',
+                         'telecom',
+                         'generalPractitioner']
+    with check:
+        for field in _sensitive_fields:
+            assert not is_key_in_dict(response_body, field), f'Sensitive field, {field}, in response.'

--- a/tests/functional/steps/when.py
+++ b/tests/functional/steps/when.py
@@ -1,0 +1,74 @@
+from pytest_bdd import when, parsers
+from requests import Response, get, patch
+from tests.functional.data.updates import Update
+from tests.functional.data.searches import Search
+from copy import copy
+import urllib
+
+
+@when('I retrieve my details', target_fixture='response')
+@when('I retrieve a patient', target_fixture='response')
+def retrieve_patient(headers_with_authorization: dict, nhs_number: str, pds_url: str) -> Response:
+    return get(url=f"{pds_url}/Patient/{nhs_number}", headers=headers_with_authorization)
+
+
+@when('I retrieve their related person', target_fixture='response')
+def retrieve_related_person(headers_with_authorization: dict, nhs_number: str, pds_url: str) -> Response:
+    return get(url=f"{pds_url}/Patient/{nhs_number}/RelatedPerson", headers=headers_with_authorization)
+
+
+@when("I update the patient's PDS record", target_fixture='response')
+@when("I update another patient's PDS record", target_fixture='response')
+def update_patient(headers_with_authorization: dict, update: Update, pds_url: str) -> Response:
+    headers = headers_with_authorization
+    headers.update({
+        "Content-Type": "application/json-patch+json",
+        "If-Match": update.etag,
+    })
+
+    return patch(url=f"{pds_url}/Patient/{update.nhs_number}",
+                 headers=headers,
+                 json=update.patches)
+
+
+@when("I update another patient's PDS record using an incorrect path", target_fixture='response')
+def update_patient_incorrect_path(headers_with_authorization: dict, update: Update, pds_url: str) -> Response:
+    headers = headers_with_authorization
+    headers.update({
+        "Content-Type": "application/json-patch+json",
+        "If-Match": update.etag,
+    })
+
+    return patch(url=f"{pds_url}/Patient?family=Smith&gender=female&birthdate=eq2010-10-22",
+                 headers=headers,
+                 json=update.patches)
+
+
+@when(
+    parsers.cfparse(
+        "I hit the /{endpoint:String} endpoint",
+        extra_types=dict(String=str)
+    ),
+    target_fixture='response'
+)
+def hit_endpoint(headers_with_authorization: dict, pds_url: str, endpoint: str):
+    return get(url=f'{pds_url}/{endpoint}', headers=headers_with_authorization)
+
+
+@when(
+    parsers.cfparse(
+        'the query parameters contain {key:String} as {value:String}',
+        extra_types=dict(String=str)
+    ),
+    target_fixture='query_params',
+)
+def amended_query_params(search: Search, key: str, value: str) -> str:
+    query_params = copy(search.query)
+    query_params.append((key, value))
+    return urllib.parse.urlencode(query_params)
+
+
+@when("I search for a patient's PDS record", target_fixture='response')
+@when("I search for the patient's PDS record", target_fixture='response')
+def search_patient(headers_with_authorization: dict, query_params: str, pds_url: str) -> Response:
+    return get(url=f"{pds_url}/Patient?{query_params}", headers=headers_with_authorization)

--- a/tests/functional/test_patient_access.py
+++ b/tests/functional/test_patient_access.py
@@ -52,6 +52,11 @@ def test_cannot_retrieve_incorrect_path():
     pass
 
 
+@retrieve_scenario('Patient cannot retrieve their record with an expired token')
+def test_cannot_retrieve_with_expired_token():
+    pass
+
+
 @update_scenario('Patient cannot update another patient')
 def test_cannot_update_another_patient():
     pass

--- a/tests/functional/test_patient_access.py
+++ b/tests/functional/test_patient_access.py
@@ -14,11 +14,11 @@ def headers_with_authorization(_nhsd_apim_auth_token_data: dict,
 
     access_token = _nhsd_apim_auth_token_data.get("access_token", "")
 
-    headers = {"X-Request-ID": str(uuid.uuid1()),
-               "X-Correlation-ID": str(uuid.uuid1()),
-               "Authorization": f'Bearer {access_token}'
-               }
-
+    headers = {
+        "X-Request-ID": str(uuid.uuid1()),
+        "X-Correlation-ID": str(uuid.uuid1()),
+        "Authorization": f'Bearer {access_token}'
+    }
     return headers
 
 

--- a/tests/functional/test_patient_access.py
+++ b/tests/functional/test_patient_access.py
@@ -9,7 +9,6 @@ from pytest_bdd import given
 
 @pytest.fixture(scope='function')
 def headers_with_authorization(_nhsd_apim_auth_token_data: dict,
-                               identity_service_base_url: str,
                                add_asid_to_testapp: None) -> dict:
     """Assign required headers with the Authorization header"""
 

--- a/tests/functional/test_smoke_tests.py
+++ b/tests/functional/test_smoke_tests.py
@@ -1,8 +1,8 @@
 from .utils import helpers
 import pytest
 import uuid
+from typing import Dict
 from tests.functional.test_user_restricted import (
-    AUTH_HEALTHCARE_WORKER,
     retrieve_scenario,
     search_scenario,
     related_person_scenario,
@@ -40,10 +40,12 @@ def identity_service_base_url():
 
 
 @pytest.fixture()
-def headers_with_authorization(apigee_environment,
-                               nhsd_apim_config,
-                               _test_app_credentials,
-                               identity_service_base_url):
+def headers_with_authorization(apigee_environment: str,
+                               nhsd_apim_config: dict,
+                               _test_app_credentials: dict,
+                               identity_service_base_url: str,
+                               user_directory: dict) -> Dict[str, str]:
+    healthcare_worker_auth = user_directory['healthcare_worker']
 
     user_restricted_app_config = AuthorizationCodeConfig(
             environment=apigee_environment,
@@ -53,7 +55,7 @@ def headers_with_authorization(apigee_environment,
             client_id=_test_app_credentials["consumerKey"],
             client_secret=_test_app_credentials["consumerSecret"],
             scope="nhs-cis2",
-            login_form=AUTH_HEALTHCARE_WORKER['login_form']
+            login_form=healthcare_worker_auth['login_form']
         )
 
     authenticator = AuthorizationCodeAuthenticator(config=user_restricted_app_config)

--- a/tests/functional/test_user_restricted.py
+++ b/tests/functional/test_user_restricted.py
@@ -15,14 +15,6 @@ import uuid
 from jsonpath_rw import parse
 from pytest_nhsd_apim.apigee_apis import ApiProductsAPI
 
-AUTH_HEALTHCARE_WORKER = {
-        "api_name": "personal-demographics-service",
-        "access": "healthcare_worker",
-        "level": "aal3",
-        "login_form": {"username": "656005750104"},
-        "force_new_token": True
-    }
-
 retrieve_scenario = partial(pytest_bdd.scenario, './features/healthcare_worker_retrieve.feature')
 search_scenario = partial(pytest_bdd.scenario, './features/healthcare_worker_search.feature')
 update_scenario = partial(pytest_bdd.scenario, './features/healthcare_worker_update.feature')

--- a/tests/scripts/environment.py
+++ b/tests/scripts/environment.py
@@ -18,7 +18,7 @@ class EnvVarWrapper(object):
             value = os.environ[environment_variable]
         except KeyError:
             warn(f'KeyError occured when attempting to retrieve {key} from environment variables.')
-            value = None
+            return None
 
         if os.path.isfile(value):
             with open(value) as f:

--- a/tests/scripts/environment.py
+++ b/tests/scripts/environment.py
@@ -1,4 +1,5 @@
 import os
+from warnings import warn
 
 
 class EnvVarWrapper(object):
@@ -12,8 +13,13 @@ class EnvVarWrapper(object):
         self._env = kwargs
 
     def __getitem__(self, key):
-        environment_variable = self._env[key]
-        value = os.environ[environment_variable]
+        try:
+            environment_variable = self._env[key]
+            value = os.environ[environment_variable]
+        except KeyError:
+            warn(f'KeyError occured when attempting to retrieve {key} from environment variables.')
+            value = None
+
         if os.path.isfile(value):
             with open(value) as f:
                 file_content = f.read()


### PR DESCRIPTION
## Summary
Add test scenario that gets an expired access token, adds it to the auth header and have a patient attempt to retrieve their details.

As part of the work, I also split up the pytest_bdd steps in to their own files as conftest was becoming cluttered.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
