### PR TITLE
SPINEDEM-1820 Add test for refresh tokens using Patient Access mode

### DIFF
--- a/tests/functional/features/patient_access_retrieve.feature
+++ b/tests/functional/features/patient_access_retrieve.feature
@@ -40,3 +40,12 @@ Feature: Patient Access (Retrieve)
 		Then I get a 401 HTTP response code
 		And ACCESS_DENIED is at issue[0].details.coding[0].code in the response body
 		And Access Token expired is at issue[0].diagnostics in the response body
+
+	Scenario: Patient can retrieve their record with a refreshed token
+		Given I am a P9 user
+		And scope added to product
+		And I have an refreshed access token
+
+		When I retrieve my details
+
+		Then I get a 200 HTTP response code

--- a/tests/functional/features/patient_access_retrieve.feature
+++ b/tests/functional/features/patient_access_retrieve.feature
@@ -44,7 +44,7 @@ Feature: Patient Access (Retrieve)
 	Scenario: Patient can retrieve their record with a refreshed token
 		Given I am a P9 user
 		And scope added to product
-		And I have an refreshed access token
+		And I have a refreshed access token
 
 		When I retrieve my details
 

--- a/tests/functional/steps/given.py
+++ b/tests/functional/steps/given.py
@@ -177,7 +177,7 @@ def add_expired_token_to_auth_header(headers_with_authorization: dict,
     return headers_with_authorization
 
 
-@given("I have an refreshed access token", target_fixture='headers_with_authorization')
+@given("I have a refreshed access token", target_fixture='headers_with_authorization')
 def add_refresh_token_to_auth_header(headers_with_authorization: dict,
                                      identity_service_base_url: str,
                                      _nhsd_apim_auth_token_data: dict,

--- a/tests/functional/steps/given.py
+++ b/tests/functional/steps/given.py
@@ -175,3 +175,31 @@ def add_expired_token_to_auth_header(headers_with_authorization: dict,
         'Authorization': f'Bearer {token_value}'
     })
     return headers_with_authorization
+
+
+@given("I have an refreshed access token", target_fixture='headers_with_authorization')
+def add_refresh_token_to_auth_header(headers_with_authorization: dict,
+                                     identity_service_base_url: str,
+                                     _nhsd_apim_auth_token_data: dict,
+                                     _test_app_credentials: dict) -> dict:
+    old_token = _nhsd_apim_auth_token_data.get('access_token')
+    refresh_token = _nhsd_apim_auth_token_data.get('refresh_token')
+
+    response = post(
+        f"{identity_service_base_url}/token",
+        data={
+            "client_id": _test_app_credentials["consumerKey"],
+            "client_secret": _test_app_credentials["consumerSecret"],
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token
+        },
+    )
+
+    assert response.status_code == 200, f'POST /token failed. Response:\n {response.text}'
+
+    new_token = response.json()['access_token']
+    assert new_token != old_token
+    headers_with_authorization.update({
+        'Authorization': f'Bearer {new_token}'
+    })
+    return headers_with_authorization

--- a/tests/functional/test_patient_access.py
+++ b/tests/functional/test_patient_access.py
@@ -56,6 +56,11 @@ def test_cannot_retrieve_with_expired_token():
     pass
 
 
+@retrieve_scenario("Patient can retrieve their record with a refreshed token")
+def test_can_retrieve_with_refreshed_token():
+    pass
+
+
 @update_scenario('Patient cannot update another patient')
 def test_cannot_update_another_patient():
     pass


### PR DESCRIPTION
## Summary
Add a test to confirm a patient can access their details when using a refreshed token.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
