### PR TITLE
Removed internal-qa stage of deploy pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2024-01-02
+* Deleted internal-qa stage of deployment pipeline to avoid test data mismatch issues against VEIT and INT
+
 ## 2023-11-17
 * Added sandbox/init.py
 * Updated tool.poetry

--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -39,26 +39,21 @@ extends:
       - environment: internal-dev
         post_deploy:
           - template: templates/pds-tests.yml
-      - environment: internal-qa
-        post_deploy:
-          - template: templates/pds-tests.yml
-        depends_on:
-            - internal_dev
       - environment: internal-qa-sandbox
         enable_status_monitoring: false
         proxy_path: sandbox
         post_deploy:
           - template: templates/sandbox-tests.yml
+        depends_on:
+          - internal_dev
       - environment: int
         post_deploy:
            - template: templates/pds-tests-int.yml
         depends_on:
-          - internal_qa
           - internal_qa_sandbox
       - environment: ref
         enable_status_monitoring: false # revert when /_status implemented or endpoint updated
         depends_on:
-          - internal_qa
           - internal_qa_sandbox
       - environment: sandbox
         proxy_path: sandbox
@@ -66,11 +61,9 @@ extends:
         post_deploy:
           - template: templates/sandbox-tests.yml
         depends_on:
-          - internal_qa
           - internal_qa_sandbox
       - environment: prod
         depends_on:
-          - internal_qa
           - internal_qa_sandbox
         jinja_templates:
           REQUIRE_ASID: true

--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -44,16 +44,16 @@ extends:
         proxy_path: sandbox
         post_deploy:
           - template: templates/sandbox-tests.yml
-        depends_on:
-          - internal_dev
       - environment: int
         post_deploy:
            - template: templates/pds-tests-int.yml
         depends_on:
+          - internal_dev
           - internal_qa_sandbox
       - environment: ref
         enable_status_monitoring: false # revert when /_status implemented or endpoint updated
         depends_on:
+          - internal_dev
           - internal_qa_sandbox
       - environment: sandbox
         proxy_path: sandbox
@@ -61,9 +61,11 @@ extends:
         post_deploy:
           - template: templates/sandbox-tests.yml
         depends_on:
+          - internal_dev
           - internal_qa_sandbox
       - environment: prod
         depends_on:
+          - internal_dev
           - internal_qa_sandbox
         jinja_templates:
           REQUIRE_ASID: true

--- a/manifest_template.yml
+++ b/manifest_template.yml
@@ -32,23 +32,6 @@ APIGEE_ENVIRONMENTS:
           enabled: false
         spikeArrest:
           enabled: false
-  - name: internal-qa
-    display_name_suffix: Internal QA
-    ratelimiting:
-      personal-demographics-internal-qa:
-        quota:
-          enabled: true
-          limit: 300
-          interval: 1
-          timeunit: minute
-        spikeArrest:
-          enabled: true
-          ratelimit: 600pm # 10 requests per second
-      app:
-        quota:
-          enabled: false
-        spikeArrest:
-          enabled: false
   - name: internal-qa-sandbox
     display_name_suffix: Internal QA Sandbox
     # Ratelimiting is currently disabled for sandbox environments

--- a/tests/functional/utils/apigee_api_products.py
+++ b/tests/functional/utils/apigee_api_products.py
@@ -60,7 +60,7 @@ class ApigeeApiProducts(ApigeeApi):
 
     def update_environments(self, environments: list, api_products):
         """ Update the product environments """
-        permitted_environments = ["internal-dev", "internal-dev-sandbox", "internal-qa", "internal-qa-sandbox", "ref"]
+        permitted_environments = ["internal-dev", "internal-dev-sandbox", "internal-qa-sandbox", "ref"]
         if not set(environments) <= set(permitted_environments):
             raise RuntimeError(f"Failed updating environments! specified environments not permitted: {environments}"
                                f"\n Please specify valid environments: {permitted_environments}")


### PR DESCRIPTION
## Summary
This PR is to fix issues with the deploy pipeline failing, from jira:

The internal-qa stage, which only runs on the deployment pipeline, uses int test data as apposed to VEIT07 which internal-dev uses. This discrepancy in which telecoms snippets each record had was the cause of the failures. Following a discussion on the [APIM-support](https://nhsdigital-platforms.slack.com/archives/C016JRWN6AY/p1703161014007089) channel and within the team the current solution is to delete the internal-qa stage as the tests that are ran there are also ran on internal-dev. This will prevent test data mismatch problems, and stop us from having to refresh the int test data whenever there issues with it. The int stage of the pipeline runs smoke tests on int and is left untouched.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
