### PR TITLE
SPINEDEM-2584 HTML Reports for Karate Tests

### DIFF
--- a/azure/azure-pr-pipeline.yml
+++ b/azure/azure-pr-pipeline.yml
@@ -37,39 +37,39 @@ extends:
       PDS_TARGET_SERVER: spine-demographics
       REQUIRE_ASID: false
     apigee_deployments:
-        - environment: internal-dev
-          stage_name: pytest_bdd_tests
-          post_deploy:
-            - template: templates/pds-tests.yml
+        # - environment: internal-dev
+        #   stage_name: pytest_bdd_tests
+        #   post_deploy:
+        #     - template: templates/pds-tests.yml
         - environment: internal-dev
           stage_name: karate_tests
           post_deploy:
             - template: templates/pds-tests-karate.yml
-          depends_on:
-            - pytest_bdd_tests
-        - environment: internal-dev
-          service_name: ${{ variables.service_name }}-asid-required
-          short_service_name: ${{ variables.short_service_name }}-asid
-          service_base_path: ${{ variables.service_base_path }}-asid-required
-          stage_name: internal_dev_asid_required
-          jinja_templates:
-            PDS_TARGET_SERVER: spine-demographics
-            REQUIRE_ASID: true
-          post_deploy:
-            - template: templates/pds-tests.yml
-          depends_on:
-            - karate_tests
+          # depends_on:
+          #   - pytest_bdd_tests
+        # - environment: internal-dev
+        #   service_name: ${{ variables.service_name }}-asid-required
+        #   short_service_name: ${{ variables.short_service_name }}-asid
+        #   service_base_path: ${{ variables.service_base_path }}-asid-required
+        #   stage_name: internal_dev_asid_required
+        #   jinja_templates:
+        #     PDS_TARGET_SERVER: spine-demographics
+        #     REQUIRE_ASID: true
+        #   post_deploy:
+        #     - template: templates/pds-tests.yml
+        #   depends_on:
+        #     - karate_tests
         
-        - environment: internal-dev-sandbox
-          proxy_path: sandbox
-          post_deploy:
-            - template: templates/sandbox-tests.yml
+        # - environment: internal-dev-sandbox
+        #   proxy_path: sandbox
+        #   post_deploy:
+        #     - template: templates/sandbox-tests.yml
 
-        - environment: internal-dev
-          service_name: ${{ variables.service_name }}-int
-          short_service_name: ${{ variables.short_service_name }}-int
-          service_base_path: ${{ variables.service_base_path }}-int
-          stage_name: internal_dev_int
-          jinja_templates:
-            PDS_TARGET_SERVER: spine-demographics-int
-            REQUIRE_ASID: false
+        # - environment: internal-dev
+        #   service_name: ${{ variables.service_name }}-int
+        #   short_service_name: ${{ variables.short_service_name }}-int
+        #   service_base_path: ${{ variables.service_base_path }}-int
+        #   stage_name: internal_dev_int
+        #   jinja_templates:
+        #     PDS_TARGET_SERVER: spine-demographics-int
+        #     REQUIRE_ASID: false

--- a/azure/azure-pr-pipeline.yml
+++ b/azure/azure-pr-pipeline.yml
@@ -37,39 +37,39 @@ extends:
       PDS_TARGET_SERVER: spine-demographics
       REQUIRE_ASID: false
     apigee_deployments:
-        # - environment: internal-dev
-        #   stage_name: pytest_bdd_tests
-        #   post_deploy:
-        #     - template: templates/pds-tests.yml
+        - environment: internal-dev
+          stage_name: pytest_bdd_tests
+          post_deploy:
+            - template: templates/pds-tests.yml
         - environment: internal-dev
           stage_name: karate_tests
           post_deploy:
             - template: templates/pds-tests-karate.yml
-          # depends_on:
-          #   - pytest_bdd_tests
-        # - environment: internal-dev
-        #   service_name: ${{ variables.service_name }}-asid-required
-        #   short_service_name: ${{ variables.short_service_name }}-asid
-        #   service_base_path: ${{ variables.service_base_path }}-asid-required
-        #   stage_name: internal_dev_asid_required
-        #   jinja_templates:
-        #     PDS_TARGET_SERVER: spine-demographics
-        #     REQUIRE_ASID: true
-        #   post_deploy:
-        #     - template: templates/pds-tests.yml
-        #   depends_on:
-        #     - karate_tests
+          depends_on:
+            - pytest_bdd_tests
+        - environment: internal-dev
+          service_name: ${{ variables.service_name }}-asid-required
+          short_service_name: ${{ variables.short_service_name }}-asid
+          service_base_path: ${{ variables.service_base_path }}-asid-required
+          stage_name: internal_dev_asid_required
+          jinja_templates:
+            PDS_TARGET_SERVER: spine-demographics
+            REQUIRE_ASID: true
+          post_deploy:
+            - template: templates/pds-tests.yml
+          depends_on:
+            - karate_tests
         
-        # - environment: internal-dev-sandbox
-        #   proxy_path: sandbox
-        #   post_deploy:
-        #     - template: templates/sandbox-tests.yml
+        - environment: internal-dev-sandbox
+          proxy_path: sandbox
+          post_deploy:
+            - template: templates/sandbox-tests.yml
 
-        # - environment: internal-dev
-        #   service_name: ${{ variables.service_name }}-int
-        #   short_service_name: ${{ variables.short_service_name }}-int
-        #   service_base_path: ${{ variables.service_base_path }}-int
-        #   stage_name: internal_dev_int
-        #   jinja_templates:
-        #     PDS_TARGET_SERVER: spine-demographics-int
-        #     REQUIRE_ASID: false
+        - environment: internal-dev
+          service_name: ${{ variables.service_name }}-int
+          short_service_name: ${{ variables.short_service_name }}-int
+          service_base_path: ${{ variables.service_base_path }}-int
+          stage_name: internal_dev_int
+          jinja_templates:
+            PDS_TARGET_SERVER: spine-demographics-int
+            REQUIRE_ASID: false

--- a/azure/templates/pds-tests-karate.yml
+++ b/azure/templates/pds-tests-karate.yml
@@ -55,12 +55,12 @@ steps:
     displayName: 'Publish Karate HTML test report as an artifact'
     condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')
     inputs:
-      pathToPublish: $(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)/karate-tests/target/cucumber-html-reports
+      pathToPublish: $(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)/karate-tests/target/karate-reports
       artifactName: KarateHTMLReports
 
   - task: publishhtmlreport@1
-    displayName: 'Publish HTML test report'
+    displayName: 'Publish HTML Summary report'
     condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')
     inputs:
       htmlType: 'genericHTML'
-      htmlPath: $(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)/karate-tests/target/cucumber-html-reports/*.*
+      htmlPath: $(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)/karate-tests/target/karate-reports/karate-summary.html

--- a/azure/templates/pds-tests-karate.yml
+++ b/azure/templates/pds-tests-karate.yml
@@ -50,3 +50,17 @@ steps:
     inputs:
       testResultsFiles: $(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)/karate-tests/target/karate-reports/*.xml
       failTaskOnFailedTests: true
+
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Karate HTML test report as an artifact'
+    condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')
+    inputs:
+      pathToPublish: $(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)/karate-tests/target/cucumber-html-reports
+      artifactName: KarateHTMLReports
+
+  - task: publishhtmlreport@1
+    displayName: 'Publish HTML test report'
+    condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')
+    inputs:
+      htmlType: 'genericHTML'
+      htmlPath: $(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)/karate-tests/target/cucumber-html-reports/overview-steps.html

--- a/azure/templates/pds-tests-karate.yml
+++ b/azure/templates/pds-tests-karate.yml
@@ -57,10 +57,3 @@ steps:
     inputs:
       pathToPublish: $(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)/karate-tests/target/karate-reports
       artifactName: KarateHTMLReports
-
-  - task: publishhtmlreport@1
-    displayName: 'Publish HTML Summary report'
-    condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')
-    inputs:
-      htmlType: 'genericHTML'
-      htmlPath: $(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)/karate-tests/target/karate-reports/karate-summary.html

--- a/azure/templates/pds-tests-karate.yml
+++ b/azure/templates/pds-tests-karate.yml
@@ -63,4 +63,4 @@ steps:
     condition: in(variables['Agent.JobStatus'], 'Succeeded', 'SucceededWithIssues', 'Failed')
     inputs:
       htmlType: 'genericHTML'
-      htmlPath: $(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)/karate-tests/target/cucumber-html-reports/overview-steps.html
+      htmlPath: $(Pipeline.Workspace)/s/$(SERVICE_NAME)/$(SERVICE_ARTIFACT_NAME)/karate-tests/target/cucumber-html-reports/*.*

--- a/karate-tests/README.md
+++ b/karate-tests/README.md
@@ -11,17 +11,28 @@ You probably have Java installed as it's part of the main codebase build.
 
 To avoid having to install a newer version of Java later when Karate demands it, you may want to install openjdk 17. This is what we run on CI too. It shouldn't break any of the existing `make` commands we have that use Java.
 
-`sudo apt update sudo apt install openjdk-17-jdk`
+```bash
+sudo apt update sudo apt install openjdk-17-jdk
+```
 
 ### Maven
 
 Maven is a build tool for Java. We use it to install dependencies and run the Karate tests. Live life to the max: treat yourself to the latest version!
 
 1. Go to the directory where you want to install (unpack) maven. This may be a folder you use for other software too. It's not overly important - what's important is you tell your shell the path to the folder afterwards.
-1. Download Maven. The latest version at the time of writing was: `wget https://dlcdn.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz`
-1. Unpack it. `tar xzvf apache-maven-3.9.6-bin.tar.gz`
+1. Download Maven. The latest version at the time of writing was: 
+```bash
+wget https://dlcdn.apache.org/maven/maven-3/3.9.6/binaries/apache-maven-3.9.6-bin.tar.gz
+```
+1. Unpack it. 
+```bash
+tar xzvf apache-maven-3.9.6-bin.tar.gz
+```
 1. Add the path to the `bin` folder of your `apache-maven-3.9.6` path to your PATH env variable
-1. Reload the shell and verify Maven is on your path `mvn --version`
+1. Reload the shell and verify Maven is on your path
+```bash
+mvn --version
+```
 
 
 ## Running the tests
@@ -33,20 +44,49 @@ All of the tests run against what's currently deployed on veit07.
 To run the tests, make sure you are in the `karate-tests` folder.
 
 Run all the functional tests in parallel:
-    - `mvn test -Dtest=TestParallel`
+```bash
+mvn test -Dtest=TestParallel
+```
 
 There are also individual JUnit tests for running specific feature files. These may be more useful if you're developing / debugging tests and you only want to run certain scenarios.
 
 Run all the tests in a given test file:
-    - `mvn test -Dtest=HealthcareWorkerTests`
+```bash
+mvn test -Dtest=HealthcareWorkerTests
+```
 
 Run only one of the tests in a given test file:
-    - `mvn test -Dtest=HealthcareWorkerTests#testGetPatient`
+```
+bash mvn test -Dtest=HealthcareWorkerTests#testGetPatient
+```
 
 ### Load tests
 To see an example of how Karate can repurpose functional tests as a load test, we've got the `PatientsSimulation.scala` file, which lets us run the `getPatient.feature` file using Gatling:
 
 Run the load tests:
-    - `mvn clean test-compile gatling:test`
+```bash
+mvn clean test-compile gatling:test
+```
 
-Whoosh!
+## CI Setup
+
+As with other tests, the CI process takes place on both Github and Azure DevOps (ADO). 
+
+- In `.github/workflows/continuous-integration-workflow.yaml` you'll find the steps that are run on Github relating to installing Java and Maven.
+- In the `Makefile`, a vital thing to note is how in the `release` operation we copy the `karate-tests` folder (`cp -R karate-tests dist`). This `release` step essentially builds the folder structure in ADO, so to be able to run the Karate tests it is vital to copy the `karate-tests` folder.
+- In `azure/azure-pr-pipeline` you'll find the definition of the `karate-tests` stage that is run in ADO as part of the `build` pipeline. As with the other stages of the build, the `karate-tests` stage is in the `apigee_deployments` section:
+```yaml
+- environment: internal-dev
+  stage_name: karate_tests
+  post_deploy:
+    - template: templates/pds-tests-karate.yml
+  depends_on:
+    - pytest_bdd_tests
+```
+- You can see that this section calls on the `pds-tests-karate.yml` template, which defines the actual steps that are run as part of the `karate-tests` stage.
+
+### Test reporting in ADO
+
+The `pds-tests-karate.yml` template runs the Karate tests and then publishes the results in two different ways:
+1. The `PublishTestResults@2` task is called upon to read the JUnit XML results that were produced by the test run, and these results are published in the `Tests` tab of the build phase. More info on this ADO task [can be found here](https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/publish-test-results-v2?view=azure-pipelines&tabs=trx%2Ctrxattachments%2Cyaml)
+1. The `PublishBuildArtifacts@1` task is call upon to publish the Karate HTML reports that were produced by the test run. These results are available as downloadable build artifacts - you can download the whole folder as a zip file and then uncompress on your machine to view the results. More info on this ADO task [can be found here](https://learn.microsoft.com/en-us/azure/devops/pipelines/artifacts/build-artifacts?view=azure-devops&tabs=yaml)

--- a/karate-tests/pom.xml
+++ b/karate-tests/pom.xml
@@ -56,13 +56,7 @@
             <artifactId>javafaker</artifactId>
             <version>${javafaker.version}</version>
         </dependency>
-        <dependency>
-            <groupId>net.masterthought</groupId>
-            <artifactId>cucumber-reporting</artifactId>
-            <version>5.3.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
+        <!-- <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
@@ -71,7 +65,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>
-        </dependency>
+        </dependency> -->
     </dependencies>
 
     <build>

--- a/karate-tests/pom.xml
+++ b/karate-tests/pom.xml
@@ -56,8 +56,7 @@
             <artifactId>javafaker</artifactId>
             <version>${javafaker.version}</version>
         </dependency>
-        <!-- why does activating these mean I lose request details in the html report? -->
-        <!-- <dependency>
+        <dependency>
             <groupId>net.masterthought</groupId>
             <artifactId>cucumber-reporting</artifactId>
             <version>5.3.1</version>
@@ -72,8 +71,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>
-        </dependency> -->
-        <!-- why does activating these mean I lose request details in the html report? -->
+        </dependency>
     </dependencies>
 
     <build>

--- a/karate-tests/src/test/java/patients/TestParallel.java
+++ b/karate-tests/src/test/java/patients/TestParallel.java
@@ -2,6 +2,17 @@ package patients;
 
 import com.intuit.karate.Results;
 import com.intuit.karate.Runner;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import net.masterthought.cucumber.Configuration;
+import net.masterthought.cucumber.ReportBuilder;
+
+import org.apache.commons.io.FileUtils;
+
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
@@ -11,10 +22,25 @@ public class TestParallel {
     @Test
     void testDevParallel() {
         Results results = Runner.path("classpath:patients")
+                .outputCucumberJson(true)
                 .outputJunitXml(true)
                 .karateEnv("dev")
-                .parallel(1);
+                .parallel(5);
         assertTrue(results.getFailCount() == 0, results.getErrorMessages());
+
+        generateReport(results.getReportDir());
+        assertEquals(0, results.getFailCount(), results.getErrorMessages());
+    }
+
+    public static void generateReport(String karateOutputPath) {
+        Collection<File> jsonFiles = FileUtils.listFiles(new File(karateOutputPath), new String[] {"json"}, true);
+        List<String> jsonPaths = new ArrayList<String>(jsonFiles.size());
+        for(File file : jsonFiles){
+            jsonPaths.add(file.getAbsolutePath());
+        }
+        Configuration config = new Configuration(new File("target"), "REST API Automation - Karate");
+        ReportBuilder reportBuilder = new ReportBuilder(jsonPaths, config);
+        reportBuilder.generateReports();
     }
 
 }

--- a/karate-tests/src/test/java/patients/TestParallel.java
+++ b/karate-tests/src/test/java/patients/TestParallel.java
@@ -2,17 +2,6 @@ package patients;
 
 import com.intuit.karate.Results;
 import com.intuit.karate.Runner;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
-import net.masterthought.cucumber.Configuration;
-import net.masterthought.cucumber.ReportBuilder;
-
-import org.apache.commons.io.FileUtils;
-
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
@@ -22,25 +11,10 @@ public class TestParallel {
     @Test
     void testDevParallel() {
         Results results = Runner.path("classpath:patients")
-                .outputCucumberJson(true)
                 .outputJunitXml(true)
                 .karateEnv("dev")
                 .parallel(5);
         assertTrue(results.getFailCount() == 0, results.getErrorMessages());
-
-        generateReport(results.getReportDir());
-        assertEquals(0, results.getFailCount(), results.getErrorMessages());
-    }
-
-    public static void generateReport(String karateOutputPath) {
-        Collection<File> jsonFiles = FileUtils.listFiles(new File(karateOutputPath), new String[] {"json"}, true);
-        List<String> jsonPaths = new ArrayList<String>(jsonFiles.size());
-        for(File file : jsonFiles){
-            jsonPaths.add(file.getAbsolutePath());
-        }
-        Configuration config = new Configuration(new File("target"), "REST API Automation - Karate");
-        ReportBuilder reportBuilder = new ReportBuilder(jsonPaths, config);
-        reportBuilder.generateReports();
     }
 
 }


### PR DESCRIPTION
## Summary
:sparkles: New Feature
* Exports the html reports for karate tests as an artifact
* And running 5 tests in parallel as standard, while we're tweaking things

In the end, we won't be using cucumber reports, since we can't publish multiple files on ADO (only a single html file, which isn't much use). Exporting the regular Karate HTML reports as an artifact is good enough.

Add any other relevant notes or explanations here. **Remove this line if you have nothing to add.**


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
