### PR TITLE
Update smoke pack to not include app restricted tests

### DIFF
--- a/karate-tests/src/test/java/patients/appRestricted/getPatient.feature
+++ b/karate-tests/src/test/java/patients/appRestricted/getPatient.feature
@@ -12,7 +12,6 @@ Feature: get /Patient - Application-restricted access mode
     * param email = "jane.smith@example.com" 
     * param phone = "01632960587"
 
-  @smoke  
   Scenario: All headers provided
     * configure headers = requestHeaders 
     * path "Patient"

--- a/karate-tests/src/test/java/patients/healthcareWorker/searchForAPatient/searchParams.feature
+++ b/karate-tests/src/test/java/patients/healthcareWorker/searchForAPatient/searchParams.feature
@@ -24,6 +24,7 @@ Background:
   * url baseURL
 
 
+@smoke
 Scenario:Search for a patient using parameters
   * path "Patient"
   * params  { family: "Jones", gender: "male", birthdate: "ge1992-01-01", _max-results: "6" }


### PR DESCRIPTION
## Summary

The smoke tests against int were failing because of an issue with the JWT token encoding. This may well have been because there's no JWT token available. The pytest smoke test pack didn't include any app restricted tests so never ran the JWT authentication routine.

This PR removes the app restricted test from the new smoke pack, and this hopefully means the smoke tests will run in the int environment.