### PR TITLE
SPINEDEM-3996 Fix failing test - Patient can update their emergency contact

### DIFF
--- a/karate-tests/README.md
+++ b/karate-tests/README.md
@@ -64,6 +64,11 @@ The newer variable you may not have defined is `INTERNAL_SERVER_BASE_URI` - ask 
 
 All of the tests run against what's currently deployed on veit07.
 
+### A note on test data
+
+Because veit07 is a separate environment, test patients can be modified between automated test runs, and by other testers who use the environment. This means you'll need to be cautious in the way you write assertions.
+There is also a limit of how many P9 patients exist, [consult this page before using a patient for a new tpye of request.](https://nhsd-confluence.digital.nhs.uk/display/DEMGRPH/NHS+Numbers+with+NHS+Login+for+FHIR+on+VEIT07)
+
 ### Functional tests 
 
 To run the tests, make sure you are in the `karate-tests` folder.

--- a/karate-tests/README.md
+++ b/karate-tests/README.md
@@ -67,7 +67,7 @@ All of the tests run against what's currently deployed on veit07.
 ### A note on test data
 
 Because veit07 is a separate environment, test patients can be modified between automated test runs, and by other testers who use the environment. This means you'll need to be cautious in the way you write assertions.
-There is also a limit of how many P9 patients exist, [consult this page before using a patient for a new tpye of request.](https://nhsd-confluence.digital.nhs.uk/display/DEMGRPH/NHS+Numbers+with+NHS+Login+for+FHIR+on+VEIT07)
+There is also a limit of how many P9 patients exist, [consult this page before using a patient for a new type of request.](https://nhsd-confluence.digital.nhs.uk/display/DEMGRPH/NHS+Numbers+with+NHS+Login+for+FHIR+on+VEIT07)
 
 ### Functional tests 
 

--- a/karate-tests/src/test/java/patients/patientAccess/updatePatient.feature
+++ b/karate-tests/src/test/java/patients/patientAccess/updatePatient.feature
@@ -142,7 +142,7 @@ Feature: Patient updates their details
   
 
   Scenario: Patient can update their emergency contact details and place of birth
-    * def p9number = '9900000285'
+    * def p9number = '5900069176'
     * def accessToken = karate.call('classpath:auth/auth-redirect.feature', {userID: p9number, scope: 'nhs-login'}).accessToken
     * def requestHeaders = call read('classpath:auth/auth-headers.js')
     * configure headers = requestHeaders


### PR DESCRIPTION
## Summary
Test was failing as Lindsey had reset it. It was agreed that the previous record would be for use in manual tests, so I've changed it to one of the other p9s. 
https://nhsd-confluence.digital.nhs.uk/pages/viewpage.action?spaceKey=DEMGRPH&title=NHS+Numbers+with+NHS+Login+for+FHIR+on+VEIT07 has been created to managed which patients should be used for what purpose.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
