### PR TITLE
SPINEDEM-3809 Restrict Create Patient TPS

### DIFF
--- a/karate-tests/src/test/java/patients/healthcareWorker/createPatient/postPatient.feature
+++ b/karate-tests/src/test/java/patients/healthcareWorker/createPatient/postPatient.feature
@@ -6,7 +6,7 @@ Note the use of the Karate retry functionality in this feature:
   - `* retry until responseStatus != 429 && responseStatus != 503`
 
 We're using it because:
-- the post patient functionality is subject to a spik arrest policy, 
+- the post patient functionality is subject to a spike arrest policy, 
     whereby requests can be rejected with a 429 response.
 - the system may also throw a SERVICE_UNAVAILABLE error - "The downstream 
   domain processing has not completed within the configured timeout period. 

--- a/proxies/live/apiproxy/policies/SpikeArrest.PatientCreate.xml
+++ b/proxies/live/apiproxy/policies/SpikeArrest.PatientCreate.xml
@@ -2,6 +2,6 @@
 <SpikeArrest async="false" continueOnError="false" enabled="true" name="SpikeArrest.PatientCreate">
     <DisplayName>SpikeArrest.PatientCreate</DisplayName>
     <Properties/>
-    <Rate>5ps</Rate>
+    <Rate>3ps</Rate>
     <UseEffectiveCount>true</UseEffectiveCount>
 </SpikeArrest>

--- a/tests/functional/features/post_patient.feature
+++ b/tests/functional/features/post_patient.feature
@@ -1,7 +1,7 @@
 Feature: Post Patient Spike Arrest Policy
 
-Scenario: The rate limit is tripped when POSTing new Patients (>5tps)
+Scenario: The rate limit is tripped when POSTing new Patients (>3tps)
     Given I am a healthcare worker user
-    When I post to the Patient endpoint more than 5 times per second
+    When I post to the Patient endpoint more than 3 times per second
     Then I get a mix of 400 and 429 HTTP response codes
     And the 429 response bodies alert me that there have been too many Create Patient requests

--- a/tests/functional/test_patient_create.py
+++ b/tests/functional/test_patient_create.py
@@ -21,7 +21,7 @@ from tests.functional.utils.helpers import get_role_id_from_user_info_endpoint
 scenario = partial(pytest_bdd.scenario, './features/post_patient.feature')
 
 
-@scenario('The rate limit is tripped when POSTing new Patients (>5tps)')
+@scenario('The rate limit is tripped when POSTing new Patients (>3tps)')
 def test_post_patient_rate_limit():
     pass
 

--- a/tests/functional/test_patient_create.py
+++ b/tests/functional/test_patient_create.py
@@ -114,7 +114,7 @@ async def _create_all_patients(headers, url, body, loop, num_patients):
 # ---------------------------------------------------------------------------------------------------------------
 # WHEN------------------------------------------------------------------------------------------------------------
 @pytest.mark.asyncio
-@when("I post to the Patient endpoint more than 5 times per second", target_fixture='post_results')
+@when("I post to the Patient endpoint more than 3 times per second", target_fixture='post_results')
 def post_patient_multiple_times(healthcare_worker_auth_headers: dict, pds_url: str) -> list:
     # firing 30 requests in 5 seconds should trigger the spike arrest policy
     # about 5 times...

--- a/tests/functional/test_patient_create.py
+++ b/tests/functional/test_patient_create.py
@@ -147,13 +147,13 @@ def post_patient_multiple_times(healthcare_worker_auth_headers: dict, pds_url: s
 def assert_expected_spike_arrest_response_codes(post_results):
     successful_requests = [x for x in post_results if x['status'] == 400]
     spike_arrests = [x for x in post_results if x['status'] == 429]
-    actual_number_of_spike_arrest_responses = len(spike_arrests)
+    actual_number_of_spike_arrests = len(spike_arrests)
 
     patients_to_create = 40
     target_time_between_first_and_last_request = 10
-    expected_minimum_number_of_spike_arrest_responses = int(patients_to_create / target_time_between_first_and_last_request)
+    expected_minimum_number_of_spike_arrests = int(patients_to_create / target_time_between_first_and_last_request)
 
-    assert actual_number_of_spike_arrest_responses >= expected_minimum_number_of_spike_arrest_responses
+    assert actual_number_of_spike_arrests >= expected_minimum_number_of_spike_arrests
     assert len(successful_requests) + len(spike_arrests) == len(post_results)
 
 


### PR DESCRIPTION
## Summary

Non-functional testing of the new POST /Patient endpoint found that 3 TPS was the maximum throughput that should be allowed. As such, the spike arrest policy and associated tests and documentation has moved from 5 TPS to 3 TPS.


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
