### PR TITLE
SPINEDEM- 4099 Remove auth header from karatesandbox

### DIFF
--- a/karate-tests/src/test/java/auth/auth-headers.js
+++ b/karate-tests/src/test/java/auth/auth-headers.js
@@ -1,6 +1,6 @@
 function fn() {
   var client_id = karate.get('clientID');
-  var accessToken = karate.get('accessToken') 
+  var accessToken = karate.get('accessToken')
   var correlation_id = '' + java.util.UUID.randomUUID(); 
   var request_id = '' + java.util.UUID.randomUUID(); 
   

--- a/karate-tests/src/test/java/auth/authentication.feature
+++ b/karate-tests/src/test/java/auth/authentication.feature
@@ -19,8 +19,8 @@ Background:
 
 @mock
 Scenario: Mock authentication
-    # We don't authenticate. We set a value that isn't a UUID, that the mock accepts
-    * def accessToken = "HEALTHCARE_WORKER"
+    # We don't authenticate on sandbox. We set a example value that follows bearer token format
+    * def accessToken = "g1112R_ccQ1Ebbb4gtHBP1aaaNM"
 
 @real
 Scenario: Call the real oauth2 authentication mock service
@@ -89,3 +89,4 @@ Scenario: Call the real oauth2 authentication mock service
     * status 200
 
     * def accessToken = response.access_token
+  

--- a/karate-tests/src/test/java/mocks/sandbox/post-patient.js
+++ b/karate-tests/src/test/java/mocks/sandbox/post-patient.js
@@ -119,19 +119,6 @@ function postPatientRequestIsValid (request) {
   return true
 }
 
-function userHasPermission (request) {
-  // check the user making the request has permission to create a patient
-  let valid = true
-  if (request.header('Authorization') === 'Bearer APP_RESTRICTED') {
-    const body = context.read('classpath:mocks/stubs/errorResponses/INVALID_METHOD.json')
-    body.issue[0].details.coding[0].display = 'Cannot create resource with application-restricted access token'
-    response.body = body
-    response.status = 403
-    valid = false
-  }
-  return valid
-}
-
 function initializePatientData (request) {
   const patient = JSON.parse(JSON.stringify(NEW_PATIENT))
 
@@ -161,7 +148,7 @@ function initializePatientData (request) {
 function handlePatientCreationRequest (request) {
   response.headers = basicResponseHeaders(request)
   response.contentType = 'application/fhir+json'
-  if (userHasPermission(request) && postPatientRequestIsValid(request)) {
+  if (postPatientRequestIsValid(request)) {
     if (!requestMatchesErrorScenario(request)) {
       const patient = initializePatientData(request)
       response.body = patient

--- a/karate-tests/src/test/java/mocks/sandbox/supporting-functions.js
+++ b/karate-tests/src/test/java/mocks/sandbox/supporting-functions.js
@@ -99,15 +99,13 @@ context.read('classpath:helpers/nhs-number-validator.js')
  * @returns {boolean} - Returns true if the string is a valid UUID, otherwise false.
  */
 function isValidUUID (uuid) {
-  let valid = false
-  const specialTokens = ['APP_RESTRICTED', 'HEALTHCARE_WORKER']
-  if (specialTokens.includes(uuid)) {
-    valid = true
-  } else {
-    const regex = /[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}/
-    valid = regex.test(uuid)
-  }
-  return valid
+  const regex = /[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}/
+  return regex.test(uuid)
+}
+
+function isValidAuthToken (token) {
+  const regex = /^(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z0-9]+(_[a-zA-Z0-9]+)?$/
+  return regex.test(token)
 }
 
 /*
@@ -129,7 +127,7 @@ function isValidBearerToken (token) {
     return false
   } else if (tokenParts[0] !== 'Bearer') {
     return false
-  } else if (!isValidUUID(tokenParts[1])) {
+  } else if (!isValidAuthToken(tokenParts[1])) {
     return false
   }
   return true
@@ -147,8 +145,8 @@ function validateAuthHeader (request) {
   // Check if the Authorization header is present and correct
   const authorization = request.header('Authorization')
   if (authorization === null) {
-    diagnostics = 'Missing Authorization header'
-    valid = false
+    // authorization is not mandatory on sandbox
+    valid = true
   } else if (!containsBearerToken(authorization)) {
     diagnostics = 'Missing access token'
     valid = false

--- a/karate-tests/src/test/java/mocks/sandbox/supporting-functions.js
+++ b/karate-tests/src/test/java/mocks/sandbox/supporting-functions.js
@@ -111,7 +111,7 @@ function isValidAuthToken (token) {
 /*
  * validate the oauth2 bearer token
  */
-function validateBearerToken (token, validateTokenPart = false) {
+function isValidBearerToken (token, validateTokenPart = false) {
   const tokenParts = token.split(' ')
   if (tokenParts.length !== 2 || tokenParts[0] !== 'Bearer') {
     return false
@@ -136,10 +136,10 @@ function validateAuthHeader (request) {
   if (authorization === null) {
     // authorization is not mandatory on sandbox
     valid = true
-  } else if (!validateBearerToken(authorization)) {
+  } else if (!isValidBearerToken(authorization)) {
     diagnostics = 'Missing access token'
     valid = false
-  } else if (!validateBearerToken(authorization, true)) {
+  } else if (!isValidBearerToken(authorization, true)) {
     diagnostics = 'Invalid Access Token'
     valid = false
   }

--- a/karate-tests/src/test/java/mocks/sandbox/supporting-functions.js
+++ b/karate-tests/src/test/java/mocks/sandbox/supporting-functions.js
@@ -111,23 +111,12 @@ function isValidAuthToken (token) {
 /*
  * validate the oauth2 bearer token
  */
-function containsBearerToken (token) {
+function validateBearerToken(token, validateTokenPart = false) {
   const tokenParts = token.split(' ')
-  if (tokenParts.length !== 2) {
-    return false
-  } else if (tokenParts[0] !== 'Bearer') {
+  if (tokenParts.length !== 2 || tokenParts[0] !== 'Bearer') {
     return false
   }
-  return true
-}
-
-function isValidBearerToken (token) {
-  const tokenParts = token.split(' ')
-  if (tokenParts.length !== 2) {
-    return false
-  } else if (tokenParts[0] !== 'Bearer') {
-    return false
-  } else if (!isValidAuthToken(tokenParts[1])) {
+  if (validateTokenPart && !isValidAuthToken(tokenParts[1])) {
     return false
   }
   return true
@@ -147,10 +136,10 @@ function validateAuthHeader (request) {
   if (authorization === null) {
     // authorization is not mandatory on sandbox
     valid = true
-  } else if (!containsBearerToken(authorization)) {
+  } else if (!validateBearerToken(authorization)) {
     diagnostics = 'Missing access token'
     valid = false
-  } else if (!isValidBearerToken(authorization)) {
+  } else if (!validateBearerToken(authorization, true)) {
     diagnostics = 'Invalid Access Token'
     valid = false
   }

--- a/karate-tests/src/test/java/mocks/sandbox/supporting-functions.js
+++ b/karate-tests/src/test/java/mocks/sandbox/supporting-functions.js
@@ -111,7 +111,7 @@ function isValidAuthToken (token) {
 /*
  * validate the oauth2 bearer token
  */
-function validateBearerToken(token, validateTokenPart = false) {
+function validateBearerToken (token, validateTokenPart = false) {
   const tokenParts = token.split(' ')
   if (tokenParts.length !== 2 || tokenParts[0] !== 'Bearer') {
     return false

--- a/karate-tests/src/test/java/patients/appRestricted/authentication.feature
+++ b/karate-tests/src/test/java/patients/appRestricted/authentication.feature
@@ -12,7 +12,7 @@ Background:
 @mock
 Scenario: Mock authentication
     # We don't authenticate. We set a value that isn't a UUID, that the mock accepts
-    * def accessToken = "APP_RESTRICTED"
+    * def accessToken = "g1112R_ccQ1Ebbb4gtHBP1aaaNM"
 
 @real
 Scenario: Authentication for application-restricted access - signed JWT authentication

--- a/karate-tests/src/test/java/patients/appRestricted/createPatientError.feature
+++ b/karate-tests/src/test/java/patients/appRestricted/createPatientError.feature
@@ -1,4 +1,4 @@
-@sandbox @no-oas
+@no-oas
 Feature: Create patient - not permitted for application-restricted users
   A spike arrest policy is in a place for this endpoint, and the spike arrest policy 
   takes priority over the authentication rules. Even though we can't create a patient

--- a/karate-tests/src/test/java/patients/healthcareWorker/invalidHeaders/invalidHeaders.feature
+++ b/karate-tests/src/test/java/patients/healthcareWorker/invalidHeaders/invalidHeaders.feature
@@ -66,7 +66,7 @@ Scenario Outline: x-request-id errors: patient <operation> - <diagnostics>
     | get          | 1234                       | Invalid value - '1234' in header 'X-Request-ID'                                             | INVALID_VALUE   |
     | search       | 1234                       | Invalid value - '1234' in header 'X-Request-ID'                                             | INVALID_VALUE   |
 
-  @sandbox-only-fix
+  @sandbox-only
   Scenario Outline: Auth errors: patient <operation> - <diagnostics> 
     * def query = operation == 'search' ? { family: "Capon", gender: "male", birthdate: "eq1953-05-29" } : null
     * def target = operation == 'search' ? 'Patient' : `Patient/${nhsNumber}`


### PR DESCRIPTION
## Summary

1. Added logic on karate sandbox to accept requests with or without an authorization token, but validate the format of provided tokens: If an invalid authorization token format is sent, then sandbox would return an appropriate error response
2. Removed @sandbox tag from tests that check the comparative behaviour between the difference access modes.
3. Added sandbox only test to check the Invalid authorization header behaviour
4. Added example access token to mock tests


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
