### PR TITLE
Define the search set bundle in which EHIC details and meta.versionID will sit

### DIFF
--- a/specification/components/schemas/CoverageSearch.yaml
+++ b/specification/components/schemas/CoverageSearch.yaml
@@ -25,7 +25,7 @@ properties:
       versionId:
         type: string
         description: The NHS England assigned version of the coverage.
-        pattern: "^\d+$"
+        pattern: "^\\d+$"
         example: "2"
   entry:
     type: array

--- a/specification/components/schemas/CoverageSearch.yaml
+++ b/specification/components/schemas/CoverageSearch.yaml
@@ -3,11 +3,11 @@ properties:
   resourceType:
     type: string
     description: FHIR Resource Type.
-    default: Bundle
+    enum: [Bundle]
   type:
     type: string
     description: FHIR Bundle Type.
-    default: searchset
+    enum: [searchset]
   timestamp:
     type: string
     description: Time the search was performed.

--- a/specification/components/schemas/CoverageSearch.yaml
+++ b/specification/components/schemas/CoverageSearch.yaml
@@ -1,0 +1,38 @@
+type: object
+properties:
+  resourceType:
+    type: string
+    description: FHIR Resource Type.
+    default: Bundle
+  type:
+    type: string
+    description: FHIR Bundle Type.
+    default: searchset
+  timestamp:
+    type: string
+    description: Time the search was performed.
+    format: datetime
+    example: '2019-12-25T12:00:00+00:00'
+  total:
+    type: integer
+    description: Number of resources returned in search.
+    minimum: 0
+    maximum: 1
+  meta:
+    type: object
+    description: Metadata about this resource.
+    properties:
+      versionId:
+        type: string
+        description: The NHS England assigned version of the coverage.
+        pattern: "^\d+$"
+        example: "2"
+  entry:
+    type: array
+    description: |
+      A list of matched coverages. Empty if none found.
+    items:
+      type: object
+      properties:
+        resource:
+          $ref: Coverage.yaml


### PR DESCRIPTION
## Summary
When returning EHIC details, PDS FHIR API will place them inside a bundle along with a Meta resource, enabling `versionId` to be communicated when reading and updating.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
