### PR TITLE
SPINEDEM-3511 Change update text - should have only one of each communication type

### DIFF
--- a/specification/components/schemas/Patient.yaml
+++ b/specification/components/schemas/Patient.yaml
@@ -40,7 +40,7 @@ properties:
   telecom:
     type: array
     description: |
-      List of contact points for the patient, like phone numbers or email addresses. A patient should only have one instance of each telecom value on their record at a time. For example, to add a new work email value to the record, the existing work email value should be replaced with the new value. When a patient tagged as `restricted` is retrieved, all contact points, like phone numbers or email addresses, are removed from the response.
+      List of contact points for the patient, like phone numbers or email addresses. A patient should only have one instance of each telecom system and use combination on their record at a time. For example, to add a new work email value to the record, the existing work email value should be replaced with the new value. When a patient tagged as `restricted` is retrieved, all contact points, like phone numbers or email addresses, are removed from the response.
     items:
       $ref: "ContactPoint.yaml"
   contact:

--- a/specification/components/schemas/Patient.yaml
+++ b/specification/components/schemas/Patient.yaml
@@ -40,7 +40,7 @@ properties:
   telecom:
     type: array
     description: |
-      List of contact points for the patient; for example, phone numbers or email addresses. When a patient tagged as `restricted` is retrieved, all contact points are removed from the response (a contact point, such as a phone number or email address).
+      List of contact points for the patient, like phone numbers or email addresses. A patient should only have one instance of each telecom value on their record at a time. For example, to add a new work email value to the record, the existing work email value should be replaced with the new value. When a patient tagged as `restricted` is retrieved, all contact points, like phone numbers or email addresses, are removed from the response.
     items:
       $ref: "ContactPoint.yaml"
   contact:

--- a/specification/personal-demographics.yaml
+++ b/specification/personal-demographics.yaml
@@ -1460,6 +1460,20 @@ paths:
         * `/telecom/0` if the telecom to be replaced or removed is the first item in the list. If it is the second item in the list the path is `/telecom/1`, and so on
         * `/telecom/-` when adding a new telecom
 
+        In PDS, a telecom is made up of two values: a 'system' and a 'use'. The telecom system values are:
+        * phone
+        * fax
+        * email
+        * other
+
+        The telecom use values are:
+        * home
+        * work
+        * temp
+        * mobile
+        
+        A patient should only have one instance of each telecom value on their record at a time. For example, to add a new work email value to the record, the existing work email value should be replaced with the new value.
+        
         Emergency contact details should not be added to the `telecom` field, instead they should be added to the `contact` field.
 
         There are a number of business rules that should be taken into account:


### PR DESCRIPTION
## Summary
* Routine Change

Update to the information in the FHIR API OAS file related to telecom system and use. The changes explain the distinction between telecom system and use before explaining that there should only be one instance of each combination of these on a patient's record at a time. I.e. if a new work email address, home phone number or other system/use combination is added, it should replace any existing value for that combination. 

Note that this is not coded into the API and nor is it planned to be. However, it is a business expectation that users will use the API in the way detailed above. 


## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
