### PR TITLE
Clear beta status on PDS FHIR API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ venv
 
 __pycache__/
 .envrc
+.tool-versions
 .vscode
 .mypy_cache
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ curl -sSL https://install.python-poetry.org | python3
 poetry install
 ```
 
-Install nvm & npn
+Install nvm & npm
 ```bash
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
 # Close and reopen your terminal window, or use 'exec $SHELL'


### PR DESCRIPTION
## Summary
* Routine Change

- latest commit `+clearstatus` description will result in the `-beta` tag being removed from the [next version](https://github.com/NHSDigital/personal-demographics-service-api/releases) which was annoying me slightly since this is an NHS Platinum service.
- small changes to `calculate_version.py` to remove magic strings
- minor typo fix and added .tool-versions in case people use `asdf` for managing local tool versions

## Reviews Required
* [] Dev

## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
