### PR TITLE
Ensure JIRA ticket comment is only create on PR:opened

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -1,5 +1,7 @@
 name: PR Quality Check
-on: pull_request
+on:
+  pull_request:
+    types: [opened]
 
 permissions:
   actions: write


### PR DESCRIPTION
## Summary
* Routine Change

Minor improvement to the pr-lint workflow.

Currently, every time you push to a branch with an open PR a new JIRA comment is added to the ticket due to the PR synchronize event. We therefore have adjusted it so it will only be created on the PR being opened.

I have assessed the contents of the changed file and am happy that the logic to only run on a PR being opened is sound.

## Reviews Required
* [ ] Dev


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
