### PR TITLE
SPINEDEM-101 Add Jira description only once and remove Beta release status

### DIFF
--- a/.github/workflows/pr-lint.yaml
+++ b/.github/workflows/pr-lint.yaml
@@ -1,5 +1,7 @@
 name: PR Quality Check
-on: pull_request
+on:
+  pull_request:
+    types: [opened]
 
 permissions:
   actions: write

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ venv
 
 __pycache__/
 .envrc
-.tool-versions
 .vscode
 .mypy_cache
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ venv
 
 __pycache__/
 .envrc
+.tool-versions
 .vscode
 .mypy_cache
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ curl -sSL https://install.python-poetry.org | python3
 poetry install
 ```
 
-Install nvm & npn
+Install nvm & npm
 ```bash
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.2/install.sh | bash
 # Close and reopen your terminal window, or use 'exec $SHELL'


### PR DESCRIPTION
## Summary
* Routine Change

**Changes:**

- Adjusted PR lint job, which links the JIRA ticket, so just run on the PR being opened.
- Minor refactoring of the `calculate_version.py` script to be more readable (think this one just shipped with the APIM default repo).
- Added a commit that includes the flag `+clearstatus` - this will mean, as long as this commit is included when merged, then the `-beta` suffix will no longer appear in the release tag that is automatically created. This version tag also appears in the OAS schema that is accessible from the public facing PDS FHIR API page: https://digital.nhs.uk/restapi/oas/320398

**Test**
- PR Lint job seems to only print once. I tested out adding an additional commit which would previously result in a new JIRA link being added. You will see that only one JIRA link is added
- Ran `poetry run python scripts/calculate_version.py` locally and confirmed it no longer has the beta status. I think this will only take effect when merged to master. See lines 76 & 81 in `.github/workflows/continuous-integration-workflow.yaml`

## Reviews Required
* [ ] Dev


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
