### PR TITLE
SPINEDEM-2318 added invalid request id sandbox test for allocate nhs …

### DIFF
--- a/karate-tests/src/test/java/mocks/sandbox/post-patient.js
+++ b/karate-tests/src/test/java/mocks/sandbox/post-patient.js
@@ -2,7 +2,7 @@
 /* global context, request, response */
 
 /* functions defined in supporting-functions.js */
-/* global basicResponseHeaders */
+/* global basicResponseHeaders,validateHeaders */
 
 /*
  * Generating valid NHS numbers on the fly isn't so easy, so we just have an array of valid numbers
@@ -153,11 +153,14 @@ function initializePatientData (request) {
 function handlePatientCreationRequest (request) {
   response.headers = basicResponseHeaders(request)
   response.contentType = 'application/fhir+json'
-  if (postPatientRequestIsValid(request)) {
-    if (!requestMatchesErrorScenario(request)) {
-      const patient = initializePatientData(request)
-      response.body = patient
-      response.status = 201
+  const isRequestHeadersValid = validateHeaders(request)
+  if (isRequestHeadersValid) {
+    if (postPatientRequestIsValid(request)) {
+      if (!requestMatchesErrorScenario(request)) {
+        const patient = initializePatientData(request)
+        response.body = patient
+        response.status = 201
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- As part of this PR added Missing X-Request-ID and invalid X-Request-ID sandbox scenarios.
- The scenarios for 'New NHS Number Allocated', 'Single Match Found', and 'Multiple Matches Found' have already been implemented and are available in the master branch.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
